### PR TITLE
SDL2Window: Use SDL_Vulkan_GetInstanceExtensions() to obtain extensions

### DIFF
--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -22,12 +22,22 @@ SDL2Window::SDL2Window(DisplayWindowHost *windowHost) : windowHost(windowHost)
         std::runtime_error(message.c_str());
     }
 
-    auto instance = VulkanInstanceBuilder()
-		.RequireExtension(VK_KHR_SURFACE_EXTENSION_NAME)
-		.RequireExtension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME)
-		.OptionalExtension(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME)
-		.DebugLayer(false)
-		.Create();
+    // Generate a required extensions list
+    unsigned int extCount;
+    SDL_Vulkan_GetInstanceExtensions(m_SDLWindow, &extCount, nullptr);
+    const char** extNames = new const char*[extCount];
+    SDL_Vulkan_GetInstanceExtensions(m_SDLWindow, &extCount, extNames);
+
+    // Create the instance
+    auto instanceBuilder = VulkanInstanceBuilder();
+    for (int i = 0 ; i < extCount ; i++)
+    {
+        instanceBuilder.RequireExtension(std::string(extNames[i]));
+    }
+    instanceBuilder.OptionalExtension(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME)
+                   .DebugLayer(false);
+    auto instance = instanceBuilder.Create();
+    delete[] extNames;
 
     VkSurfaceKHR surfaceHandle;
     SDL_Vulkan_CreateSurface(m_SDLWindow, instance->Instance, &surfaceHandle);


### PR DESCRIPTION
I've mainly did this to get rid of the compiling error I've been getting over "VK_KHR_XLIB_SURFACE_EXTENSION_NAME" but I think it should also be done anyways considering requesting for an Xlib surface wouldn't make sense in a pure Wayland environment.

I had thought of adding a RequireExtensions() function to VulkanInstanceBuilder for slightly simpler code in here but ultimately decided against modifying the third party libraries, and now I think of it again, there wouldn't be that much of a simplification.