### PR TITLE
Win32Window: Fix infinite loop

### DIFF
--- a/SurrealEngine/Window/Win32/Win32Window.cpp
+++ b/SurrealEngine/Window/Win32/Win32Window.cpp
@@ -237,7 +237,10 @@ std::string Win32Window::GetAvailableResolutions() const
 			}
 		}
 		if (resolutionAlreadyAdded)
+		{
+			modeNum++;
 			continue;
+		}
 
 		// Add the resolution, as it is not added before
 		availableResolutions.push_back(resolution);


### PR DESCRIPTION
Forgot the increment modeNum in the case of a resolution that has been already added, causing EnumDisplaySettings() to query the same resolution over and over and over and over and over and over again...

Whoops.