### PR TITLE
SDL2Window mini-changes

### DIFF
--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -15,7 +15,8 @@ SDL2Window::SDL2Window(DisplayWindowHost *windowHost) : windowHost(windowHost)
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
         SDLWindowError("Unable to initialize SDL: " + std::string(SDL_GetError());
     }
-    m_SDLWindow = SDL_CreateWindow("Surreal Engine", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1366, 768, SDL_WINDOW_VULKAN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+    // Width and height won't matter much as the window will be resized based on the values in [GameExecutableName].ini anyways
+    m_SDLWindow = SDL_CreateWindow("Surreal Engine", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_VULKAN);
     if (!m_SDLWindow) {
         SDLWindowError("Unable to create SDL Window: " + std::string(SDL_GetError());
     }

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -342,8 +342,14 @@ int SDL2Window::GetPixelHeight() const
 
 double SDL2Window::GetDpiScale() const
 {
+    /*
+     * From the SDL2 documentation:
+     * It is almost always better to use SDL_GetWindowSize() to find the window size, which might be in logical points instead of pixels,
+     * and then SDL_GL_GetDrawableSize(), SDL_Vulkan_GetDrawableSize(), SDL_Metal_GetDrawableSize(), or SDL_GetRendererOutputSize(),
+     * and compare the two values to get an actual scaling value between the two.
+     */
     int drawable_width, window_width;
-    SDL_GetWindowSizeInPixels(m_SDLWindow, &window_width, nullptr);
+    SDL_GetWindowSize(m_SDLWindow, &window_width, nullptr);
     SDL_Vulkan_GetDrawableSize(m_SDLWindow, &drawable_width, nullptr);
 
     return (double) drawable_width / (double) window_width;

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -144,8 +144,23 @@ void SDL2Window::SetWindowTitle(const std::string& text)
 
 void SDL2Window::SetWindowFrame(const Rect& box)
 {
-    SDL_SetWindowPosition(m_SDLWindow, box.x, box.y);
-    SDL_SetWindowSize(m_SDLWindow, box.width, box.height);
+    if (isFullscreen)
+    {
+        // Fullscreen windows are handled with SDL_DisplayMode
+        SDL_DisplayMode mode;
+        SDL_GetWindowDisplayMode(m_SDLWindow, &mode);
+        mode.w = box.width;
+        mode.h = box.height;
+        mode.refresh_rate = 0;
+        int set_result = SDL_SetWindowDisplayMode(m_SDLWindow, &mode);
+        if (set_result < 0)
+            SDLWindowError("Error on SDL_SetWindowDisplayMode(): " + std::string(SDL_GetError()));
+    }
+    else
+    {
+        SDL_SetWindowPosition(m_SDLWindow, box.x, box.y);
+        SDL_SetWindowSize(m_SDLWindow, box.width, box.height);
+    }
 }
 
 void SDL2Window::SetClientFrame(const Rect& box)
@@ -161,6 +176,7 @@ void SDL2Window::Show()
 void SDL2Window::ShowFullscreen()
 {
     SDL_SetWindowFullscreen(m_SDLWindow, SDL_WINDOW_FULLSCREEN);
+    isFullscreen = true;
 }
 
 void SDL2Window::ShowMaximized()
@@ -175,7 +191,9 @@ void SDL2Window::ShowMinimized()
 
 void SDL2Window::ShowNormal()
 {
-    SDL_RestoreWindow(m_SDLWindow);
+    // Clear the Fullscreen flag
+    SDL_SetWindowFullscreen(m_SDLWindow, 0);
+    isFullscreen = false;
 }
 
 void SDL2Window::Hide()

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -13,13 +13,11 @@ std::map<int, SDL2Window*> SDL2Window::windows;
 SDL2Window::SDL2Window(DisplayWindowHost *windowHost) : windowHost(windowHost)
 {
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
-        std::string message = "Unable to initialize SDL: " + std::string(SDL_GetError());
-        std::runtime_error(message.c_str());
+        SDLWindowError("Unable to initialize SDL: " + std::string(SDL_GetError());
     }
     m_SDLWindow = SDL_CreateWindow("Surreal Engine", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1366, 768, SDL_WINDOW_VULKAN | SDL_WINDOW_FULLSCREEN_DESKTOP);
     if (!m_SDLWindow) {
-        std::string message = "Unable to create SDL Window: " + std::string(SDL_GetError());
-        std::runtime_error(message.c_str());
+        SDLWindowError("Unable to create SDL Window: " + std::string(SDL_GetError());
     }
 
     // Generate a required extensions list
@@ -97,6 +95,11 @@ void SDL2Window::RunLoop()
 
 void SDL2Window::ExitLoop()
 {
+}
+
+void SDL2Window::SDLWindowError(const std::string& message) const
+{
+    throw std::runtime_error(message.c_str());
 }
 
 void SDL2Window::OnSDLEvent(SDL_Event& event)
@@ -335,18 +338,12 @@ std::string SDL2Window::GetAvailableResolutions() const
     // First, obtain the display the window is on
     int displayIndex = SDL_GetWindowDisplayIndex(m_SDLWindow);
     if (displayIndex < 0)
-    {
-        std::string message{"Error on SDL_GetWindowDisplayIndex(): " + std::string(SDL_GetError())};
-        std::runtime_error(message.c_str());
-    }
+        SDLWindowError("Error on SDL_GetWindowDisplayIndex(): " + std::string(SDL_GetError()));
 
     // Then obtain the amount of available resolutions
     int numDisplayModes = SDL_GetNumDisplayModes(displayIndex);
     if (numDisplayModes < 0)
-    {
-        std::string message{"Error on SDL_GetNumDisplayModes(): " + std::string(SDL_GetError())};
-        std::runtime_error(message.c_str());
-    }
+        SDLWindowError("Error on SDL_GetNumDisplayModes(): " + std::string(SDL_GetError()));
 
     for (int i = 0 ; i < numDisplayModes ; i++)
     {

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -18,6 +18,7 @@ public:
 	static void RunLoop();
 	static void ExitLoop();
 
+	void SDLWindowError(std::string& message) const;
 	void OnSDLEvent(SDL_Event& event);
 
 	void SetWindowTitle(const std::string& text) override;

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -59,4 +59,5 @@ public:
 	std::unique_ptr<RenderDevice> rendDevice;
 
 	static std::map<int, SDL2Window*> windows;
+	bool isFullscreen = false;
 };


### PR DESCRIPTION
This PR is a little collage of changes for SDL2Window, that consist of:

- A little helper function for throwing errors
- Proper fullscreen handling
- Will no longer force the window to be fullscreen (when I initially wrote the code, I didn't realize that the resolution settings were pulled from UnrealTournament.ini)
- A little change in GetDpiScale() that *should* allow it to provide the correct scale now