### PR TITLE
Fix various Linux/Non-MSVC build errors

### DIFF
--- a/SurrealEngine/UObject/UObject.h
+++ b/SurrealEngine/UObject/UObject.h
@@ -218,7 +218,10 @@ public:
 	template<typename T>
 	T& Value(PropertyDataOffset offset) { return *static_cast<T*>(PropertyData.Ptr(offset.DataOffset)); }
 
+#ifdef _MSC_VER
+	// MSVC has a non-standard extension that makes this possible
 	template<> bool& Value(PropertyDataOffset offset) = delete; // Booleans must use BoolValue
+#endif
 
 	BitfieldBool BoolValue(PropertyDataOffset offset) { BitfieldBool b; b.Ptr = static_cast<uint32_t*>(PropertyData.Ptr(offset.DataOffset)); b.Mask = offset.BitfieldMask; return b; }
 
@@ -256,3 +259,8 @@ T* ObjectStream::ReadObject()
 {
 	return UObject::Cast<T>(package->GetUObject(ReadIndex()));
 }
+
+#ifndef _MSC_VER
+// Same deal with above, but for non-MSVC compilers
+template<> bool& UObject::Value(PropertyDataOffset offset) = delete; // Booleans must use BoolValue
+#endif

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -13,12 +13,12 @@ std::map<int, SDL2Window*> SDL2Window::windows;
 SDL2Window::SDL2Window(DisplayWindowHost *windowHost) : windowHost(windowHost)
 {
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
-        SDLWindowError("Unable to initialize SDL: " + std::string(SDL_GetError());
+        SDLWindowError("Unable to initialize SDL: " + std::string(SDL_GetError()));
     }
     // Width and height won't matter much as the window will be resized based on the values in [GameExecutableName].ini anyways
     m_SDLWindow = SDL_CreateWindow("Surreal Engine", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_VULKAN);
     if (!m_SDLWindow) {
-        SDLWindowError("Unable to create SDL Window: " + std::string(SDL_GetError());
+        SDLWindowError("Unable to create SDL Window: " + std::string(SDL_GetError()));
     }
 
     // Generate a required extensions list
@@ -98,7 +98,7 @@ void SDL2Window::ExitLoop()
 {
 }
 
-void SDL2Window::SDLWindowError(const std::string& message) const
+void SDL2Window::SDLWindowError(const std::string&& message) const
 {
     throw std::runtime_error(message.c_str());
 }

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -18,7 +18,7 @@ public:
 	static void RunLoop();
 	static void ExitLoop();
 
-	void SDLWindowError(std::string& message) const;
+	void SDLWindowError(const std::string&& message) const;
 	void OnSDLEvent(SDL_Event& event);
 
 	void SetWindowTitle(const std::string& text) override;


### PR DESCRIPTION
1. UObject: Template specializations in-class seems to be only a MSVC thing, as GCC gives out an error when trying to compile it.
2. SDL2Window had some syntax errors regarding parantheses, and some lvalue-rvalue shenanigans.

With these two changes I was able to build the engine on Linux again