### PR TITLE
setres command implementation + getcurrentres changes

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -620,7 +620,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 	}
 	else if (command == "setres" && args.size() == 2)
 	{
-		LogUnimplemented("SetRes command is not implemented: " + commandline);
+		window->SetResolution(args[1]);
 	}
 	else
 	{

--- a/SurrealEngine/GameFolder.cpp
+++ b/SurrealEngine/GameFolder.cpp
@@ -4,6 +4,7 @@
 #include "File.h"
 #include "UTF16.h"
 #include "CommandLine.h"
+#include <filesystem>
 
 GameLaunchInfo GameFolderSelection::GetLaunchInfo()
 {
@@ -16,15 +17,31 @@ GameLaunchInfo GameFolderSelection::GetLaunchInfo()
 			foundGames.push_back(game);
 	}
 
-	for (const std::string& folder : FindGameFolders())
+	if (foundGames.empty())
 	{
-		GameFolder game = ExamineFolder(folder);
-		if (!game.name.empty())
-			foundGames.push_back(game);
+		// Check if we're within an UE1-game System folder.
+		auto p = std::filesystem::current_path();
+		if (p.filename().string() == "System")
+		{
+			GameFolder game = ExamineFolder(p.parent_path().string());
+			if (!game.name.empty())
+				foundGames.push_back(game);
+		}
 	}
 
 	if (foundGames.empty())
 	{
+		for (const std::string& folder : FindGameFolders())
+		{
+			GameFolder game = ExamineFolder(folder);
+			if (!game.name.empty())
+				foundGames.push_back(game);
+		}
+	}
+	
+	if (foundGames.empty())
+	{
+		// If we STILL didn't find anything, then there is nothing else we can do
 		throw std::runtime_error("Unable to find a game folder");
 	}
 

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -107,12 +107,27 @@ void SDL2Window::OnSDLEvent(SDL_Event& event)
 {
     switch (event.type) {
     case SDL_WINDOWEVENT:
-        if (event.window.event == SDL_WINDOWEVENT_CLOSE)
-            windowHost->OnWindowClose();
-        else
-            windowHost->OnWindowGeometryChanged();
+        switch (event.window.event)
+        {
+            case SDL_WINDOWEVENT_CLOSE:
+                windowHost->OnWindowClose();
+                break;
+            case SDL_WINDOWEVENT_MOVED:
+            case SDL_WINDOWEVENT_RESIZED:
+                windowHost->OnWindowGeometryChanged();
+                break;
+            case SDL_WINDOWEVENT_SHOWN:
+            case SDL_WINDOWEVENT_EXPOSED:
+                windowHost->OnWindowPaint();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                windowHost->OnWindowActivated();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                windowHost->OnWindowDeactivated();
+                break;
+        }
         break;
-
     case SDL_TEXTINPUT:
         OnKeyboardTextInput(event.text);
         break;

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -106,13 +106,11 @@ void SDL2Window::SDLWindowError(const std::string&& message) const
 void SDL2Window::OnSDLEvent(SDL_Event& event)
 {
     switch (event.type) {
-    case SDL_QUIT:
-        windowHost->OnWindowClose();
-        break;
-
     case SDL_WINDOWEVENT:
-        // ???
-        windowHost->OnWindowGeometryChanged();
+        if (event.window.event == SDL_WINDOWEVENT_CLOSE)
+            windowHost->OnWindowClose();
+        else
+            windowHost->OnWindowGeometryChanged();
         break;
 
     case SDL_TEXTINPUT:

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -145,7 +145,7 @@ void SDL2Window::SetWindowTitle(const std::string& text)
 
 void SDL2Window::SetWindowFrame(const Rect& box)
 {
-    if (isFullscreen)
+    if (isWindowFullscreen)
     {
         // Fullscreen windows are handled with SDL_DisplayMode
         SDL_DisplayMode mode;
@@ -177,7 +177,7 @@ void SDL2Window::Show()
 void SDL2Window::ShowFullscreen()
 {
     SDL_SetWindowFullscreen(m_SDLWindow, SDL_WINDOW_FULLSCREEN);
-    isFullscreen = true;
+    isWindowFullscreen = true;
 }
 
 void SDL2Window::ShowMaximized()
@@ -194,7 +194,7 @@ void SDL2Window::ShowNormal()
 {
     // Clear the Fullscreen flag
     SDL_SetWindowFullscreen(m_SDLWindow, 0);
-    isFullscreen = false;
+    isWindowFullscreen = false;
 }
 
 void SDL2Window::Hide()

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -399,26 +399,6 @@ std::vector<Size> SDL2Window::QueryAvailableResolutions() const
     return result;
 }
 
-std::string SDL2Window::GetAvailableResolutions() const
-{
-    std::string result = "";
-
-    auto resolutions = QueryAvailableResolutions();
-
-    // "Flatten" the resolutions list into a single string
-    for (int i = 0; i < resolutions.size(); i++)
-    {
-        auto& res = resolutions[i];
-        std::string resString = std::to_string(int(res.width)) + "x" + std::to_string(int(res.height));
-
-        result += resString;
-        if (i < resolutions.size() - 1)
-            result += " ";
-    }
-
-    return result;
-}
-
 EInputKey SDL2Window::SDLScancodeToInputKey(SDL_Scancode keycode)
 {
     switch (keycode) {

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -381,7 +381,7 @@ std::vector<Size> SDL2Window::QueryAvailableResolutions() const
         // Skip over the current resolution if it is already inserted
         // (in case of multiple refresh rates being available for the display)
         bool resolutionAlreadyAdded = false;
-        for (auto res : availableResolutions)
+        for (auto res : result)
         {
             if (resolution == res)
             {

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -50,6 +50,7 @@ public:
 	int GetPixelWidth() const override;
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
+	std::vector<Size> QueryAvailableResolutions() const override;
 	std::string GetAvailableResolutions() const override;
 
 	EInputKey SDLScancodeToInputKey(SDL_Scancode keycode);

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -51,7 +51,6 @@ public:
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
 	std::vector<Size> QueryAvailableResolutions() const override;
-	std::string GetAvailableResolutions() const override;
 
 	EInputKey SDLScancodeToInputKey(SDL_Scancode keycode);
 	SDL_Scancode InputKeyToSDLScancode(EInputKey inputkey);

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -60,5 +60,4 @@ public:
 	std::unique_ptr<RenderDevice> rendDevice;
 
 	static std::map<int, SDL2Window*> windows;
-	bool isFullscreen = false;
 };

--- a/SurrealEngine/Window/Win32/Win32Window.cpp
+++ b/SurrealEngine/Window/Win32/Win32Window.cpp
@@ -114,7 +114,7 @@ void Win32Window::ShowFullscreen()
 	SetWindowLongPtr(WindowHandle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 	SetWindowLongPtr(WindowHandle, GWL_STYLE, WS_OVERLAPPED);
 	SetWindowPos(WindowHandle, HWND_TOP, 0, 0, width, height, SWP_FRAMECHANGED | SWP_SHOWWINDOW);
-	Fullscreen = true;
+	isWindowFullscreen = true;
 }
 
 void Win32Window::ShowMaximized()
@@ -267,6 +267,24 @@ std::string Win32Window::GetAvailableResolutions() const
 	}
 
 	return result;
+}
+
+void Win32Window::SetResolution(std::string& resolutionString)
+{
+	Size parsedResolution = ParseResolutionString(resolutionString);
+	if (parsedResolution.width == 0 || parsedResolution.height == 0)
+		return;
+
+	if (isWindowFullscreen)
+		parsedResolution = GetClosestResolution(parsedResolution);
+
+	Rect windowRect = GetWindowFrame();
+	double dpi = GetDpiScale();
+
+	windowRect.width = parsedResolution.width / dpi;
+	windowRect.height = parsedResolution.height / dpi;
+
+	SetWindowFrame(windowRect);
 }
 
 LRESULT Win32Window::OnWindowMessage(UINT msg, WPARAM wparam, LPARAM lparam)

--- a/SurrealEngine/Window/Win32/Win32Window.cpp
+++ b/SurrealEngine/Window/Win32/Win32Window.cpp
@@ -249,26 +249,6 @@ std::vector<Size> Win32Window::QueryAvailableResolutions() const
 	return result;
 }
 
-std::string Win32Window::GetAvailableResolutions() const
-{
-	std::string result = "";
-
-	auto resolutions = QueryAvailableResolutions();
-
-	// "Flatten" the resolutions list into a single string
-	for (int i = 0; i < resolutions.size(); i++)
-	{
-		auto& res = resolutions[i];
-		std::string resString = std::to_string(int(res.width)) + "x" + std::to_string(int(res.height));
-
-		result += resString;
-		if (i < resolutions.size() - 1)
-			result += " ";
-	}
-
-	return result;
-}
-
 void Win32Window::SetResolution(std::string& resolutionString)
 {
 	Size parsedResolution = ParseResolutionString(resolutionString);

--- a/SurrealEngine/Window/Win32/Win32Window.h
+++ b/SurrealEngine/Window/Win32/Win32Window.h
@@ -35,6 +35,7 @@ public:
 	double GetDpiScale() const override;
 	std::vector<Size> QueryAvailableResolutions() const override;
 	std::string GetAvailableResolutions() const override;
+	void SetResolution(std::string& resolutionString) override;
 
 	Point GetLParamPos(LPARAM lparam) const;
 
@@ -52,7 +53,6 @@ public:
 	DisplayWindowHost* WindowHost = nullptr;
 
 	HWND WindowHandle = 0;
-	bool Fullscreen = false;
 
 	bool MouseLocked = false;
 	POINT MouseLockPos = {};

--- a/SurrealEngine/Window/Win32/Win32Window.h
+++ b/SurrealEngine/Window/Win32/Win32Window.h
@@ -34,7 +34,6 @@ public:
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
 	std::vector<Size> QueryAvailableResolutions() const override;
-	std::string GetAvailableResolutions() const override;
 	void SetResolution(std::string& resolutionString) override;
 
 	Point GetLParamPos(LPARAM lparam) const;

--- a/SurrealEngine/Window/Win32/Win32Window.h
+++ b/SurrealEngine/Window/Win32/Win32Window.h
@@ -33,6 +33,7 @@ public:
 	int GetPixelWidth() const override;
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
+	std::vector<Size> QueryAvailableResolutions() const override;
 	std::string GetAvailableResolutions() const override;
 
 	Point GetLParamPos(LPARAM lparam) const;

--- a/SurrealEngine/Window/Window.cpp
+++ b/SurrealEngine/Window/Window.cpp
@@ -9,6 +9,9 @@
 #include "X11/X11Window.h"
 #endif
 
+#include <cstdio>
+#include <cmath>
+
 // TODO: base this off of ini setting, not dependent on OS macro
 
 #ifdef WIN32
@@ -78,3 +81,78 @@ void DisplayWindow::ExitLoop()
 }
 
 #endif
+
+Size DisplayWindow::ParseResolutionString(std::string& resolutionString)
+{
+	if (resolutionString.empty())
+		return Size(0, 0);
+
+	int width, height;
+	int parsedDataCount = sscanf(resolutionString.c_str(), "%dx%d", &width, &height);
+
+	// Handle incorrect parsings
+	// sscanf() returns EOF on input failure, or the amount of "data processed" otherwise
+	// Since we want to process width and height of a window, we expect it to return 2
+	if (parsedDataCount == EOF || parsedDataCount != 2)
+	{
+		return Size(0, 0);
+	}
+
+	// Resolution shouldn't be smaller than 640x480
+	if (width < 640 || height < 480)
+	{
+		// Maybe produce a log here too?
+		return Size(0, 0);
+	}
+
+	return Size(width, height);
+}
+
+Size DisplayWindow::GetClosestResolution(Size resolution) const
+{
+	auto resolutions = QueryAvailableResolutions();
+
+	if (resolutions.empty())
+		return resolution;
+
+	if (resolutions.size() == 1)
+		return resolutions[0];
+
+	int index = 0;
+	double minDist = abs(pow(resolutions[0].width - resolution.width, 2) + pow(resolutions[0].height - resolution.height, 2));
+
+	for (int i = 1; i < resolutions.size(); i++)
+	{
+		auto& currRes = resolutions[i];
+
+		double dist = abs(pow(currRes.width - resolution.width, 2) + pow(currRes.height - resolution.height, 2));
+
+		if (currRes == resolution)
+			return resolutions[i];
+		
+		if (dist < minDist)
+		{
+			minDist = dist;
+			index = i;
+		}
+	}
+
+	return resolutions[index];
+}
+
+void DisplayWindow::SetResolution(std::string& resolutionString)
+{
+	Size parsedResolution = ParseResolutionString(resolutionString);
+	if (parsedResolution.width == 0 || parsedResolution.height == 0)
+		return;
+
+	if (isWindowFullscreen)
+		parsedResolution = GetClosestResolution(parsedResolution);
+
+	Rect windowRect = GetWindowFrame();
+
+	windowRect.width = parsedResolution.width;
+	windowRect.height = parsedResolution.height;
+
+	SetWindowFrame(windowRect);
+}

--- a/SurrealEngine/Window/Window.cpp
+++ b/SurrealEngine/Window/Window.cpp
@@ -82,6 +82,26 @@ void DisplayWindow::ExitLoop()
 
 #endif
 
+std::string DisplayWindow::GetAvailableResolutions() const
+{
+	std::string result = "";
+
+	auto resolutions = QueryAvailableResolutions();
+
+	// "Flatten" the resolutions list into a single string
+	for (int i = 0; i < resolutions.size(); i++)
+	{
+		auto& res = resolutions[i];
+		std::string resString = std::to_string(int(res.width)) + "x" + std::to_string(int(res.height));
+
+		result += resString;
+		if (i < resolutions.size() - 1)
+			result += " ";
+	}
+
+	return result;
+}
+
 Size DisplayWindow::ParseResolutionString(std::string& resolutionString)
 {
 	if (resolutionString.empty())

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -167,7 +167,7 @@ public:
 	virtual int GetPixelHeight() const = 0;
 	virtual double GetDpiScale() const = 0;
 	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
-	virtual std::string GetAvailableResolutions() const = 0;
+	std::string GetAvailableResolutions() const;
 
 	Size ParseResolutionString(std::string& resolutionString);
 	Size GetClosestResolution(Size resolution) const;

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -166,5 +166,6 @@ public:
 	virtual int GetPixelWidth() const = 0;
 	virtual int GetPixelHeight() const = 0;
 	virtual double GetDpiScale() const = 0;
+	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
 	virtual std::string GetAvailableResolutions() const = 0;
 };

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -168,4 +168,10 @@ public:
 	virtual double GetDpiScale() const = 0;
 	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
 	virtual std::string GetAvailableResolutions() const = 0;
+
+	Size ParseResolutionString(std::string& resolutionString);
+	Size GetClosestResolution(Size resolution) const;
+	virtual void SetResolution(std::string& resolutionString);
+
+	bool isWindowFullscreen = false;
 };

--- a/SurrealEngine/Window/X11/X11Window.cpp
+++ b/SurrealEngine/Window/X11/X11Window.cpp
@@ -429,26 +429,6 @@ std::vector<Size> X11Window::QueryAvailableResolutions() const
 	return result;
 }
 
-std::string X11Window::GetAvailableResolutions() const
-{
-	std::string result = "";
-
-	auto resolutions = QueryAvailableResolutions();
-
-	// "Flatten" the resolutions list into a single string
-	for (int i = 0; i < resolutions.size(); i++)
-	{
-		auto& res = resolutions[i];
-		std::string resString = std::to_string(int(res.width)) + "x" + std::to_string(int(res.height));
-
-		result += resString;
-		if (i < resolutions.size() - 1)
-			result += " ";
-	}
-
-	return result;
-}
-
 void X11Window::ProcessEvents()
 {
 	while (XPending(X11Display::GetDisplay()) > 0)

--- a/SurrealEngine/Window/X11/X11Window.cpp
+++ b/SurrealEngine/Window/X11/X11Window.cpp
@@ -398,24 +398,23 @@ double X11Window::GetDpiScale() const
 	return dpiscale;
 }
 
-std::string X11Window::GetAvailableResolutions() const
+std::vector<Size> X11Window::QueryAvailableResolutions() const
 {
-	std::string result = "";
-	std::vector<std::string> availableResolutions{};
+	std::vector<Size> result{};
 
 	int nSizes;
 	auto screenSizes = XRRSizes(display, screen, &nSizes);
 
-	for (int i = 0 ; i <nSizes ; i++)
+	for (int i = 0; i < nSizes; i++)
 	{
-		std::string resolution = std::to_string(screenSizes[i].width) + "x" + std::to_string(screenSizes[i].height);
+		Size resolution(screenSizes[i].width, screenSizes[i].height);
 
 		// Skip over the current resolution if it is already inserted
 		// (in case of multiple refresh rates being available for the display)
 		bool resolutionAlreadyAdded = false;
-		for (auto res : availableResolutions)
+		for (auto res : result)
 		{
-			if (resolution.compare(res) == 0)
+			if (resolution == res)
 			{
 				resolutionAlreadyAdded = true;
 				break;
@@ -424,14 +423,26 @@ std::string X11Window::GetAvailableResolutions() const
 		if (resolutionAlreadyAdded)
 			continue;
 
-		availableResolutions.push_back(resolution);
+		result.push_back(resolution);
 	}
 
+	return result;
+}
+
+std::string X11Window::GetAvailableResolutions() const
+{
+	std::string result = "";
+
+	auto resolutions = QueryAvailableResolutions();
+
 	// "Flatten" the resolutions list into a single string
-	for (int i = 0 ; i < availableResolutions.size() ; i++)
+	for (int i = 0; i < resolutions.size(); i++)
 	{
-		result += availableResolutions[i];
-		if (i < availableResolutions.size() - 1)
+		auto& res = resolutions[i];
+		std::string resString = std::to_string(int(res.width)) + "x" + std::to_string(int(res.height));
+
+		result += resString;
+		if (i < resolutions.size() - 1)
 			result += " ";
 	}
 

--- a/SurrealEngine/Window/X11/X11Window.cpp
+++ b/SurrealEngine/Window/X11/X11Window.cpp
@@ -312,7 +312,7 @@ void X11Window::ShowFullscreen()
 	{
 		Atom state = atoms["_NET_WM_STATE_FULLSCREEN"];
 		XChangeProperty(display, window, atoms["_NET_WM_STATE"], XA_ATOM, 32, PropModeReplace, (unsigned char *)&state, 1);
-		is_fullscreen = true;
+		isWindowFullscreen = true;
 	}
 
 	WindowX = 0;
@@ -907,7 +907,7 @@ void X11Window::MapWindow()
 
 	is_window_mapped = true;
 
-	if (is_fullscreen)
+	if (isWindowFullscreen)
 	{
 		XSetInputFocus(display, window, RevertToParent, CurrentTime);
 		XFlush(display);

--- a/SurrealEngine/Window/X11/X11Window.h
+++ b/SurrealEngine/Window/X11/X11Window.h
@@ -63,6 +63,7 @@ public:
 	int GetPixelWidth() const override;
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
+	std::vector<Size> QueryAvailableResolutions() const override;
 	std::string GetAvailableResolutions() const override;
 
 	bool HasFocus() const;

--- a/SurrealEngine/Window/X11/X11Window.h
+++ b/SurrealEngine/Window/X11/X11Window.h
@@ -98,7 +98,6 @@ public:
 	Cursor hidden_cursor = {};
 	XSizeHints* size_hints = nullptr;
 	bool is_window_mapped = false;
-	bool is_fullscreen = false;
 	EInputKey last_press_id = IK_None;
 	Time time_at_last_press = 0;
 

--- a/SurrealEngine/Window/X11/X11Window.h
+++ b/SurrealEngine/Window/X11/X11Window.h
@@ -64,7 +64,6 @@ public:
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
 	std::vector<Size> QueryAvailableResolutions() const override;
-	std::string GetAvailableResolutions() const override;
 
 	bool HasFocus() const;
 	bool IsMinimized() const;


### PR DESCRIPTION
Don't think I can get this "perfect" anytime soon so I'll be posting whatever I have at this time.

This PR:

- Implements `setres` command (albeit with some known issues)
- Modifies how `getcurrentres` is handled and moves some functionality to the `DisplayWindow` class

Some things to note about `setres`:
- When in fullscreen mode, any "odd resolutions" entered as a command (e.g. `setres 1900x1070`) will be "snapped" to the "closest available" resolution that the display supports (so in that previous example, to 1920x1080)
- Win32Window seems to create a borderless window instead of going exclusive fullscreen, so any change of resolution simply "resizes" that said window. Plus it has a special implementation to take the dpi scale into account.
- SDL2Window: I keep getting a crash with the `Could not submit command buffer: device lost` error almost all the time. There were some times where I could change the resolution, because of that at first I thought it was some sort of a race condition; but right now I cannot change my resolution even from system settings, without my display going blank on me (both X11 and Wayland behaves the same, perhaps this is a driver issue?), so I need testing on this front, to see if this is an oddity with my computer or not.
- X11Window is not tested.