### PR TITLE
SDL2Window: Handle SDL_WINDOWEVENT_*s in OnSDLEvent()

### DIFF
--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -107,12 +107,27 @@ void SDL2Window::OnSDLEvent(SDL_Event& event)
 {
     switch (event.type) {
     case SDL_WINDOWEVENT:
-        if (event.window.event == SDL_WINDOWEVENT_CLOSE)
-            windowHost->OnWindowClose();
-        else
-            windowHost->OnWindowGeometryChanged();
+        switch (event.window.event)
+        {
+            case SDL_WINDOWEVENT_CLOSE:
+                windowHost->OnWindowClose();
+                break;
+            case SDL_WINDOWEVENT_MOVED:
+            case SDL_WINDOWEVENT_RESIZED:
+                windowHost->OnWindowGeometryChanged();
+                break;
+            case SDL_WINDOWEVENT_SHOWN:
+            case SDL_WINDOWEVENT_EXPOSED:
+                windowHost->OnWindowPaint();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                windowHost->OnWindowActivated();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                windowHost->OnWindowDeactivated();
+                break;
+        }
         break;
-
     case SDL_TEXTINPUT:
         OnKeyboardTextInput(event.text);
         break;

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -106,13 +106,11 @@ void SDL2Window::SDLWindowError(const std::string&& message) const
 void SDL2Window::OnSDLEvent(SDL_Event& event)
 {
     switch (event.type) {
-    case SDL_QUIT:
-        windowHost->OnWindowClose();
-        break;
-
     case SDL_WINDOWEVENT:
-        // ???
-        windowHost->OnWindowGeometryChanged();
+        if (event.window.event == SDL_WINDOWEVENT_CLOSE)
+            windowHost->OnWindowClose();
+        else
+            windowHost->OnWindowGeometryChanged();
         break;
 
     case SDL_TEXTINPUT:


### PR DESCRIPTION
First commit: This will allow SurrealEngine to be closed from the taskbar (or the Linux equivalent of it) when using SDL2Window, which wasn't working due to us accidentally ignoring the SDL_WINDOWEVENT_CLOSE event.

(SDL_QUIT couldn't be handled in OnSDLEvent() at all, hence the removal of that portion)

Second Commit: This will let OnSDLEvent() handle more SDL_WINDOWEVENTs, which X11Window handled its equivalents of.