### PR TITLE
Allow SurrealEngine to run from the System folder of supported UE1 games

### DIFF
--- a/SurrealEngine/GameFolder.cpp
+++ b/SurrealEngine/GameFolder.cpp
@@ -4,6 +4,7 @@
 #include "File.h"
 #include "UTF16.h"
 #include "CommandLine.h"
+#include <filesystem>
 
 GameLaunchInfo GameFolderSelection::GetLaunchInfo()
 {
@@ -16,15 +17,31 @@ GameLaunchInfo GameFolderSelection::GetLaunchInfo()
 			foundGames.push_back(game);
 	}
 
-	for (const std::string& folder : FindGameFolders())
+	if (foundGames.empty())
 	{
-		GameFolder game = ExamineFolder(folder);
-		if (!game.name.empty())
-			foundGames.push_back(game);
+		// Check if we're within an UE1-game System folder.
+		auto p = std::filesystem::current_path();
+		if (p.filename().string() == "System")
+		{
+			GameFolder game = ExamineFolder(p.parent_path().string());
+			if (!game.name.empty())
+				foundGames.push_back(game);
+		}
 	}
 
 	if (foundGames.empty())
 	{
+		for (const std::string& folder : FindGameFolders())
+		{
+			GameFolder game = ExamineFolder(folder);
+			if (!game.name.empty())
+				foundGames.push_back(game);
+		}
+	}
+	
+	if (foundGames.empty())
+	{
+		// If we STILL didn't find anything, then there is nothing else we can do
 		throw std::runtime_error("Unable to find a game folder");
 	}
 


### PR DESCRIPTION
This change allows one to run SurrealEngine within the System folder of the UE1 game it supports.

Game folder checking logic is changed around a bit:

- Topmost priority is still the folder provided as a parameter to SurrealEngine
- Next is this new check of whether we're in a System folder or not
- Last is the Windows registry checking that was there before, but now we do it only if we couldn't find any games with the previous steps

As for the implementation of it, I had used std::filesystem, as it was the simplest thing to do, and we are using C++17 by default already. If this is not to your liking, I will try to think of doing this in some other way.