### PR TITLE
All Window Classes: Common-ify some code

### DIFF
--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -368,10 +368,9 @@ double SDL2Window::GetDpiScale() const
     return (double) drawable_width / (double) window_width;
 }
 
-std::string SDL2Window::GetAvailableResolutions() const
+std::vector<Size> SDL2Window::QueryAvailableResolutions() const
 {
-    std::string result = "";
-    std::vector<std::string> availableResolutions{};
+    std::vector<Size> result{};
 
     // First, obtain the display the window is on
     int displayIndex = SDL_GetWindowDisplayIndex(m_SDLWindow);
@@ -390,32 +389,9 @@ std::string SDL2Window::GetAvailableResolutions() const
         SDL_GetDisplayMode(displayIndex, i, &displayMode);
 
         // The data also includes refresh rate but we ignore it (for now?)
-        std::string resolution = std::to_string(displayMode.w) + "x" + std::to_string(displayMode.h);
+        Size resolution(displayMode.w, displayMode.h);
 
-        // Skip over the current resolution if it is already inserted
-        // (in case of multiple refresh rates being available for the display)
-        bool resolutionAlreadyAdded = false;
-        for (auto res : availableResolutions)
-        {
-            if (resolution.compare(res) == 0)
-            {
-                resolutionAlreadyAdded = true;
-                break;
-            }
-        }
-        if (resolutionAlreadyAdded)
-            continue;
-
-        // Add the resolution, as it is not added before
-        availableResolutions.push_back(resolution);
-    }
-
-    // "Flatten" the resolutions list into a single string
-    for (int i = 0 ; i < availableResolutions.size() ; i++)
-    {
-        result += availableResolutions[i];
-        if (i < availableResolutions.size() - 1)
-            result += " ";
+        AddResolutionIfNotAdded(result, resolution);
     }
 
     return result;

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -158,7 +158,7 @@ void SDL2Window::SetWindowTitle(const std::string& text)
 
 void SDL2Window::SetWindowFrame(const Rect& box)
 {
-    if (isFullscreen)
+    if (isWindowFullscreen)
     {
         // Fullscreen windows are handled with SDL_DisplayMode
         SDL_DisplayMode mode;
@@ -190,7 +190,7 @@ void SDL2Window::Show()
 void SDL2Window::ShowFullscreen()
 {
     SDL_SetWindowFullscreen(m_SDLWindow, SDL_WINDOW_FULLSCREEN);
-    isFullscreen = true;
+    isWindowFullscreen = true;
 }
 
 void SDL2Window::ShowMaximized()
@@ -207,7 +207,7 @@ void SDL2Window::ShowNormal()
 {
     // Clear the Fullscreen flag
     SDL_SetWindowFullscreen(m_SDLWindow, 0);
-    isFullscreen = false;
+    isWindowFullscreen = false;
 }
 
 void SDL2Window::Hide()

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -50,7 +50,7 @@ public:
 	int GetPixelWidth() const override;
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
-	std::string GetAvailableResolutions() const override;
+	std::vector<Size> QueryAvailableResolutions() const override;
 
 	EInputKey SDLScancodeToInputKey(SDL_Scancode keycode);
 	SDL_Scancode InputKeyToSDLScancode(EInputKey inputkey);

--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -59,5 +59,4 @@ public:
 	std::unique_ptr<RenderDevice> rendDevice;
 
 	static std::map<int, SDL2Window*> windows;
-	bool isFullscreen = false;
 };

--- a/SurrealEngine/Window/Win32/Win32Window.cpp
+++ b/SurrealEngine/Window/Win32/Win32Window.cpp
@@ -114,7 +114,7 @@ void Win32Window::ShowFullscreen()
 	SetWindowLongPtr(WindowHandle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 	SetWindowLongPtr(WindowHandle, GWL_STYLE, WS_OVERLAPPED);
 	SetWindowPos(WindowHandle, HWND_TOP, 0, 0, width, height, SWP_FRAMECHANGED | SWP_SHOWWINDOW);
-	Fullscreen = true;
+	isWindowFullscreen = true;
 }
 
 void Win32Window::ShowMaximized()

--- a/SurrealEngine/Window/Win32/Win32Window.cpp
+++ b/SurrealEngine/Window/Win32/Win32Window.cpp
@@ -211,10 +211,9 @@ double Win32Window::GetDpiScale() const
 	return GetDpiForWindow(WindowHandle) / 96.0;
 }
 
-std::string Win32Window::GetAvailableResolutions() const
+std::vector<Size> Win32Window::QueryAvailableResolutions() const
 {
-	std::string result = "";
-	std::vector<std::string> availableResolutions{};
+	std::vector<Size> result{};
 
 	int modeNum = 0;
 	DEVMODE deviceMode = {};
@@ -223,36 +222,11 @@ std::string Win32Window::GetAvailableResolutions() const
 
 	while (EnumDisplaySettings(nullptr, modeNum, &deviceMode) != 0)
 	{
-		std::string resolution = std::to_string(deviceMode.dmPelsWidth) + "x" + std::to_string(deviceMode.dmPelsHeight);
+		Size resolution(deviceMode.dmPelsWidth, deviceMode.dmPelsHeight);
 
-		// Skip over the current resolution if it is already inserted
-        // (in case of multiple refresh rates being available for the display)
-		bool resolutionAlreadyAdded = false;
-		for (auto res : availableResolutions)
-		{
-			if (resolution.compare(res) == 0)
-			{
-				resolutionAlreadyAdded = true;
-				break;
-			}
-		}
-		if (resolutionAlreadyAdded)
-		{
-			modeNum++;
-			continue;
-		}
+		AddResolutionIfNotAdded(result, resolution);
 
-		// Add the resolution, as it is not added before
-		availableResolutions.push_back(resolution);
 		modeNum++;
-	}
-
-	// "Flatten" the resolutions list into a single string
-	for (int i = 0 ; i < availableResolutions.size() ; i++)
-	{
-		result += availableResolutions[i];
-		if (i < availableResolutions.size() - 1)
-			result += " ";
 	}
 
 	return result;

--- a/SurrealEngine/Window/Win32/Win32Window.h
+++ b/SurrealEngine/Window/Win32/Win32Window.h
@@ -51,7 +51,6 @@ public:
 	DisplayWindowHost* WindowHost = nullptr;
 
 	HWND WindowHandle = 0;
-	bool Fullscreen = false;
 
 	bool MouseLocked = false;
 	POINT MouseLockPos = {};

--- a/SurrealEngine/Window/Win32/Win32Window.h
+++ b/SurrealEngine/Window/Win32/Win32Window.h
@@ -33,7 +33,7 @@ public:
 	int GetPixelWidth() const override;
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
-	std::string GetAvailableResolutions() const override;
+	std::vector<Size> QueryAvailableResolutions() const override;
 
 	Point GetLParamPos(LPARAM lparam) const;
 

--- a/SurrealEngine/Window/Window.cpp
+++ b/SurrealEngine/Window/Window.cpp
@@ -78,3 +78,41 @@ void DisplayWindow::ExitLoop()
 }
 
 #endif
+
+std::string DisplayWindow::GetAvailableResolutions() const
+{
+	std::string result = "";
+
+	auto resolutions = QueryAvailableResolutions();
+
+	// "Flatten" the resolutions list into a single string
+	for (int i = 0; i < resolutions.size(); i++)
+	{
+		auto& res = resolutions[i];
+		std::string resString = std::to_string(int(res.width)) + "x" + std::to_string(int(res.height));
+
+		result += resString;
+		if (i < resolutions.size() - 1)
+			result += " ";
+	}
+
+	return result;
+}
+
+void DisplayWindow::AddResolutionIfNotAdded(std::vector<Size>& resList, Size resolution) const
+{
+	// Skip over the current resolution if it is already inserted
+	// (in case of multiple refresh rates being available for the display)
+	bool resolutionAlreadyAdded = false;
+	for (auto& res : resList)
+	{
+		if (resolution == res)
+		{
+			resolutionAlreadyAdded = true;
+			break;
+		}
+	}
+	if (!resolutionAlreadyAdded)
+		// Add the resolution, as it is not added before
+		resList.push_back(resolution);
+}

--- a/SurrealEngine/Window/Window.cpp
+++ b/SurrealEngine/Window/Window.cpp
@@ -103,16 +103,12 @@ void DisplayWindow::AddResolutionIfNotAdded(std::vector<Size>& resList, Size res
 {
 	// Skip over the current resolution if it is already inserted
 	// (in case of multiple refresh rates being available for the display)
-	bool resolutionAlreadyAdded = false;
 	for (auto& res : resList)
 	{
 		if (resolution == res)
-		{
-			resolutionAlreadyAdded = true;
-			break;
-		}
+			return;
 	}
-	if (!resolutionAlreadyAdded)
-		// Add the resolution, as it is not added before
-		resList.push_back(resolution);
+
+	// Add the resolution, as it is not added before
+	resList.push_back(resolution);
 }

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -167,7 +167,7 @@ public:
 	virtual int GetPixelHeight() const = 0;
 	virtual double GetDpiScale() const = 0;
 	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
-	virtual std::string GetAvailableResolutions() const;
+	std::string GetAvailableResolutions() const;
 	void AddResolutionIfNotAdded(std::vector<Size>& resList, Size resolution) const;
 
 	bool isWindowFullscreen = false;

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -169,4 +169,6 @@ public:
 	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
 	virtual std::string GetAvailableResolutions() const;
 	void AddResolutionIfNotAdded(std::vector<Size>& resList, Size resolution) const;
+
+	bool isWindowFullscreen = false;
 };

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -166,5 +166,7 @@ public:
 	virtual int GetPixelWidth() const = 0;
 	virtual int GetPixelHeight() const = 0;
 	virtual double GetDpiScale() const = 0;
-	virtual std::string GetAvailableResolutions() const = 0;
+	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
+	virtual std::string GetAvailableResolutions() const;
+	void AddResolutionIfNotAdded(std::vector<Size>& resList, Size resolution) const;
 };

--- a/SurrealEngine/Window/X11/X11Window.cpp
+++ b/SurrealEngine/Window/X11/X11Window.cpp
@@ -398,41 +398,18 @@ double X11Window::GetDpiScale() const
 	return dpiscale;
 }
 
-std::string X11Window::GetAvailableResolutions() const
+std::vector<Size> X11Window::QueryAvailableResolutions() const
 {
-	std::string result = "";
-	std::vector<std::string> availableResolutions{};
+	std::vector<Size> result{};
 
 	int nSizes;
 	auto screenSizes = XRRSizes(display, screen, &nSizes);
 
-	for (int i = 0 ; i <nSizes ; i++)
+	for (int i = 0 ; i < nSizes ; i++)
 	{
-		std::string resolution = std::to_string(screenSizes[i].width) + "x" + std::to_string(screenSizes[i].height);
+		Size resolution(screenSizes[i].width, screenSizes[i].height);
 
-		// Skip over the current resolution if it is already inserted
-		// (in case of multiple refresh rates being available for the display)
-		bool resolutionAlreadyAdded = false;
-		for (auto res : availableResolutions)
-		{
-			if (resolution.compare(res) == 0)
-			{
-				resolutionAlreadyAdded = true;
-				break;
-			}
-		}
-		if (resolutionAlreadyAdded)
-			continue;
-
-		availableResolutions.push_back(resolution);
-	}
-
-	// "Flatten" the resolutions list into a single string
-	for (int i = 0 ; i < availableResolutions.size() ; i++)
-	{
-		result += availableResolutions[i];
-		if (i < availableResolutions.size() - 1)
-			result += " ";
+		AddResolutionIfNotAdded(result, resolution);
 	}
 
 	return result;

--- a/SurrealEngine/Window/X11/X11Window.cpp
+++ b/SurrealEngine/Window/X11/X11Window.cpp
@@ -312,7 +312,7 @@ void X11Window::ShowFullscreen()
 	{
 		Atom state = atoms["_NET_WM_STATE_FULLSCREEN"];
 		XChangeProperty(display, window, atoms["_NET_WM_STATE"], XA_ATOM, 32, PropModeReplace, (unsigned char *)&state, 1);
-		is_fullscreen = true;
+		isWindowFullscreen = true;
 	}
 
 	WindowX = 0;
@@ -873,7 +873,7 @@ void X11Window::MapWindow()
 
 	is_window_mapped = true;
 
-	if (is_fullscreen)
+	if (isWindowFullscreen)
 	{
 		XSetInputFocus(display, window, RevertToParent, CurrentTime);
 		XFlush(display);

--- a/SurrealEngine/Window/X11/X11Window.h
+++ b/SurrealEngine/Window/X11/X11Window.h
@@ -97,7 +97,6 @@ public:
 	Cursor hidden_cursor = {};
 	XSizeHints* size_hints = nullptr;
 	bool is_window_mapped = false;
-	bool is_fullscreen = false;
 	EInputKey last_press_id = IK_None;
 	Time time_at_last_press = 0;
 

--- a/SurrealEngine/Window/X11/X11Window.h
+++ b/SurrealEngine/Window/X11/X11Window.h
@@ -63,7 +63,7 @@ public:
 	int GetPixelWidth() const override;
 	int GetPixelHeight() const override;
 	double GetDpiScale() const override;
-	std::string GetAvailableResolutions() const override;
+	std::vector<Size> QueryAvailableResolutions() const override;
 
 	bool HasFocus() const;
 	bool IsMinimized() const;


### PR DESCRIPTION
This PR does the following:

- Implements `GetAvailableResolutions()` in the base DisplayWindow class, which calls `QueryAvailableResolutions()`, that will handle the *Window-specific parts of it. `QueryAvailableResolutions()` will also be used for implementing some parts of the setres command.
- Implements a helper function, `AddResolutionIfNotAdded()`, that helps further commonify the `GetAvailableResolutions()` function.
- Adds an `isWindowFullscreen` boolean to base DisplayWindow class, for using with the *Window classes