### PR TITLE
Implement setres command

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -620,7 +620,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 	}
 	else if (command == "setres" && args.size() == 2)
 	{
-		LogUnimplemented("SetRes command is not implemented: " + commandline);
+		window->SetResolution(args[1]);
 	}
 	else
 	{

--- a/SurrealEngine/MainDebugger.cpp
+++ b/SurrealEngine/MainDebugger.cpp
@@ -22,7 +22,8 @@ int wmain(int argc, wchar_t* argv[])
 		for (int i = 1; i < argc; i++)
 			args.push_back(from_utf16(argv[i]));
 
-		SetProcessDPIAware();
+		//SetProcessDPIAware();
+		SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
 		InitCommonControls();
 
 		WORD winsock_version = MAKEWORD(2, 2);

--- a/SurrealEngine/MainEditor.cpp
+++ b/SurrealEngine/MainEditor.cpp
@@ -28,7 +28,8 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 			LocalFree(argv);
 		}
 
-		SetProcessDPIAware();
+		//SetProcessDPIAware();
+		SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
 		InitCommonControls();
 
 		WORD winsock_version = MAKEWORD(2, 2);

--- a/SurrealEngine/MainGame.cpp
+++ b/SurrealEngine/MainGame.cpp
@@ -28,7 +28,8 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 			LocalFree(argv);
 		}
 
-		SetProcessDPIAware();
+		//SetProcessDPIAware();
+		SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
 		InitCommonControls();
 
 		WORD winsock_version = MAKEWORD(2, 2);

--- a/SurrealEngine/Window/SDL2/SDL2Window.cpp
+++ b/SurrealEngine/Window/SDL2/SDL2Window.cpp
@@ -165,10 +165,14 @@ void SDL2Window::SetWindowFrame(const Rect& box)
         SDL_GetWindowDisplayMode(m_SDLWindow, &mode);
         mode.w = box.width;
         mode.h = box.height;
-        mode.refresh_rate = 0;
+
+        // Switch outta fullscreen, change the display mode, THEN switch back to fullscreen
+        // This avoids the device lost errors, also makes resolution switching work on Wayland
+        SDL_SetWindowFullscreen(m_SDLWindow, 0);
         int set_result = SDL_SetWindowDisplayMode(m_SDLWindow, &mode);
         if (set_result < 0)
             SDLWindowError("Error on SDL_SetWindowDisplayMode(): " + std::string(SDL_GetError()));
+        SDL_SetWindowFullscreen(m_SDLWindow, SDL_WINDOW_FULLSCREEN);
     }
     else
     {

--- a/SurrealEngine/Window/Win32/Win32Window.cpp
+++ b/SurrealEngine/Window/Win32/Win32Window.cpp
@@ -80,13 +80,27 @@ void Win32Window::SetWindowTitle(const std::string& text)
 void Win32Window::SetWindowFrame(const Rect& box)
 {
 	double dpiscale = GetDpiScale();
+	if (isWindowFullscreen)
+	{
+		DEVMODE devMode = {};
+		devMode.dmSize = sizeof(DEVMODE);
+		devMode.dmDriverExtra = 0;
+
+		devMode.dmPelsWidth = (int)std::round(box.width * dpiscale);
+		devMode.dmPelsHeight = (int)std::round(box.height * dpiscale);
+
+		devMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
+
+		// Does not work properly on the resolutions <1280x1024 + 1360x768 due to Windows also changing the DPI scale
+		// We get a much smaller window instead (Due to the calculation [Resolution / [Previous Screen DPI Scale] * 1.0])
+		ChangeDisplaySettings(&devMode, CDS_FULLSCREEN);
+	}
 	SetWindowPos(WindowHandle, nullptr, (int)std::round(box.x * dpiscale), (int)std::round(box.y * dpiscale), (int)std::round(box.width * dpiscale), (int)std::round(box.height * dpiscale), SWP_NOACTIVATE | SWP_NOZORDER);
 }
 
 void Win32Window::SetClientFrame(const Rect& box)
 {
 	double dpiscale = GetDpiScale();
-
 	RECT rect = {};
 	rect.left = (int)std::round(box.x * dpiscale);
 	rect.top = (int)std::round(box.y * dpiscale);
@@ -130,6 +144,7 @@ void Win32Window::ShowMinimized()
 void Win32Window::ShowNormal()
 {
 	ShowWindow(WindowHandle, SW_NORMAL);
+	isWindowFullscreen = false;
 }
 
 void Win32Window::Hide()

--- a/SurrealEngine/Window/Window.cpp
+++ b/SurrealEngine/Window/Window.cpp
@@ -8,6 +8,8 @@
 #else
 #include "X11/X11Window.h"
 #endif
+#include <cstdio>
+#include <cmath>
 
 // TODO: base this off of ini setting, not dependent on OS macro
 
@@ -111,4 +113,90 @@ void DisplayWindow::AddResolutionIfNotAdded(std::vector<Size>& resList, Size res
 
 	// Add the resolution, as it is not added before
 	resList.push_back(resolution);
+}
+
+Size DisplayWindow::ParseResolutionString(std::string& resolutionString) const
+{
+	if (resolutionString.empty())
+		return Size(0, 0);
+
+	int width, height;
+	int parsedDataCount = sscanf(resolutionString.c_str(), "%dx%d", &width, &height);
+
+	// Handle incorrect parsings
+	// sscanf() returns EOF on input failure, or the amount of "data processed" otherwise
+	// Since we want to process width and height of a window, we expect it to return 2
+	if (parsedDataCount == EOF || parsedDataCount != 2)
+	{
+		return Size(0, 0);
+	}
+
+	// Resolution shouldn't be smaller than 640x480
+	if (width < 640 || height < 480)
+	{
+		// Maybe produce a log here too?
+		return Size(0, 0);
+	}
+
+	return Size(width, height);
+}
+
+Size DisplayWindow::GetClosestResolution(Size resolution) const
+{
+	auto resolutions = QueryAvailableResolutions();
+
+	if (resolutions.empty())
+		return resolution;
+
+	if (resolutions.size() == 1)
+		return resolutions[0];
+
+	int index = 0;
+	double minDist = abs(pow(resolutions[0].width - resolution.width, 2) + pow(resolutions[0].height - resolution.height, 2));
+
+	for (int i = 1; i < resolutions.size(); i++)
+	{
+		auto& currRes = resolutions[i];
+
+		double dist = abs(pow(currRes.width - resolution.width, 2) + pow(currRes.height - resolution.height, 2));
+
+		if (currRes == resolution)
+			return resolutions[i];
+
+		if (dist < minDist)
+		{
+			minDist = dist;
+			index = i;
+		}
+	}
+
+	return resolutions[index];
+}
+
+void DisplayWindow::SetResolution(std::string& resolutionString)
+{
+	Size parsedResolution = ParseResolutionString(resolutionString);
+	if (parsedResolution == Size(0, 0))
+		return;
+
+	Rect windowRect = GetWindowFrame();
+
+	if (isWindowFullscreen)
+	{
+		parsedResolution = GetClosestResolution(parsedResolution);
+		windowRect.x = 0;
+		windowRect.y = 0;
+	}
+		
+	
+#ifdef WIN32
+	auto dpi = GetDpiScale();
+	windowRect.width = parsedResolution.width / dpi;
+	windowRect.height = parsedResolution.height / dpi;
+#else
+	windowRect.width = parsedResolution.width;
+	windowRect.height = parsedResolution.height;
+#endif
+
+	SetWindowFrame(windowRect);
 }

--- a/SurrealEngine/Window/Window.h
+++ b/SurrealEngine/Window/Window.h
@@ -169,6 +169,9 @@ public:
 	virtual std::vector<Size> QueryAvailableResolutions() const = 0;
 	std::string GetAvailableResolutions() const;
 	void AddResolutionIfNotAdded(std::vector<Size>& resList, Size resolution) const;
+	Size ParseResolutionString(std::string& resolutionString) const;
+	Size GetClosestResolution(Size resolution) const;
+	void SetResolution(std::string& resolutionString);
 
 	bool isWindowFullscreen = false;
 };


### PR DESCRIPTION
This implements the `setres` command, based on the work from #44, so the details I mentioned there mostly apply here too. I say mostly because, the little changes from this PR:

- Allows Win32Window to also switch the display resolution, ~~though the only caveat is that it gets a bit funky in certain low resolutions because Windows also changes the DPI scale alongside the resolution, yet GetDpiScale() still returns the scale of the previous resolution for some reason.~~ Edit: This issue is fixed now. 
- Fixes the `device lost` errors in SDL2Window by not directly changing the resolution, but instead switching off from fullscreen first, then changing the display resolution, THEN changing back to fullscreen.