### PR TITLE
SDL2Window: Allow running natively on Wayland

### DIFF
--- a/SurrealEngine/Window/SDL2/SDL2Window.h
+++ b/SurrealEngine/Window/SDL2/SDL2Window.h
@@ -59,4 +59,5 @@ public:
 	std::unique_ptr<RenderDevice> rendDevice;
 
 	static std::map<int, SDL2Window*> windows;
+	static bool exitRunLoop;
 };


### PR DESCRIPTION
This implements `RunLoop()` and `ExitLoop()` in SDL2Window, so running SurrealEngine with `SDL_VIDEODRIVER="wayland"` no longer results in the window not showing up.