### PR TITLE
Make CanvasFont less hardcoded

### DIFF
--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -286,6 +286,27 @@ std::vector<std::string> Directory::files(const std::string &filename)
 
 #endif
 
+std::string OS::get_fonts_folder()
+{
+#ifdef WIN32
+	return "C:\\Windows\\Fonts";
+#else
+	// TODO: No macOS stuff yet
+	// TODO: Also this seems highly dependent on distro???
+	return "/usr/share/fonts/TTF";
+#endif
+}
+
+std::string OS::get_default_font_name()
+{
+#ifdef WIN32
+	return "segoeui";
+#else
+	// TODO: No macOS stuff yet either
+	return "DejaVuSans";
+#endif
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 bool FilePath::has_extension(const std::string &filename, const char *checkext)

--- a/SurrealEngine/File.h
+++ b/SurrealEngine/File.h
@@ -57,6 +57,13 @@ public:
 	static std::vector<std::string> files(const std::string &filename);
 };
 
+class OS
+{
+public:
+	static std::string get_fonts_folder();
+	static std::string get_default_font_name();
+};
+
 class FilePath
 {
 public:

--- a/SurrealEngine/File.h
+++ b/SurrealEngine/File.h
@@ -60,8 +60,8 @@ public:
 class OS
 {
 public:
-	static std::string get_fonts_folder();
 	static std::string get_default_font_name();
+	static std::string find_truetype_font(const std::string& font_name);
 };
 
 class FilePath

--- a/SurrealEngine/UI/Core/Canvas.cpp
+++ b/SurrealEngine/UI/Core/Canvas.cpp
@@ -36,7 +36,11 @@ class CanvasFont
 public:
 	CanvasFont(const std::string& fontname, double height) : fontname(fontname), height(height)
 	{
-		data = File::read_all_bytes("C:\\Windows\\Fonts\\segoeui.ttf");
+		std::string fonts_folder = OS::get_fonts_folder();
+
+		std::string full_font_path = FilePath::combine(fonts_folder, fontname + ".ttf");
+
+		data = File::read_all_bytes(full_font_path);
 		loadFont(data.data(), data.size());
 
 		try
@@ -237,7 +241,7 @@ RenderDeviceCanvas::RenderDeviceCanvas(RenderDevice* renderDevice) : renderDevic
 {
 	uint32_t white = 0xffffffff;
 	whiteTexture = createTexture(1, 1, &white);
-	font = std::make_unique<CanvasFont>("Segoe UI", 13.0*uiscale);
+	font = std::make_unique<CanvasFont>(OS::get_default_font_name(), 13.0*uiscale);
 }
 
 RenderDeviceCanvas::~RenderDeviceCanvas()

--- a/SurrealEngine/UI/Core/Canvas.cpp
+++ b/SurrealEngine/UI/Core/Canvas.cpp
@@ -36,9 +36,10 @@ class CanvasFont
 public:
 	CanvasFont(const std::string& fontname, double height) : fontname(fontname), height(height)
 	{
-		std::string fonts_folder = OS::get_fonts_folder();
+		std::string full_font_path = OS::find_truetype_font(fontname);
 
-		std::string full_font_path = FilePath::combine(fonts_folder, fontname + ".ttf");
+		if (full_font_path.empty())
+			throw std::runtime_error("Couldn't find font " + fontname);
 
 		data = File::read_all_bytes(full_font_path);
 		loadFont(data.data(), data.size());


### PR DESCRIPTION
This adds some font checking mechanisms, and assumptions about what fonts are default on each platform.

All of the new stuff are added inside a new OS class, as the functions and what they return are OS-specific. Though they can be moved to somewhere else if need be.