### PR TITLE
PackageManager improvements

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -32,7 +32,8 @@ Engine::Engine(GameLaunchInfo launchinfo) : LaunchInfo(launchinfo)
 {
 	engine = this;
 
-	packages = std::make_unique<PackageManager>(LaunchInfo.folder, LaunchInfo.engineVersion, LaunchInfo.gameName);
+	//packages = std::make_unique<PackageManager>(LaunchInfo.folder, LaunchInfo.engineVersion, LaunchInfo.gameName);
+	packages = std::make_unique<PackageManager>(LaunchInfo);
 }
 
 Engine::~Engine()

--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -462,7 +462,7 @@ std::string FilePath::combine(const std::string &path1, const std::string &path2
 	else if (path2_conv.empty())
 		return path1_conv;
 	else if (path2_conv.front() == '/')
-		return path2;
+		return path2_conv;
 	else if (path1_conv.back() != '/')
 		return path1_conv + "/" + path2_conv;
 	else

--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -373,6 +373,40 @@ std::string FilePath::remove_extension(const std::string &filename)
 		return filename.substr(0, filename.length() - file.length() + pos);
 }
 
+std::string FilePath::first_component(const std::string& path)
+{
+#ifdef WIN32
+	auto first_slash = path.find_first_of("/\\");
+	if (first_slash != std::string::npos)
+		return path.substr(0, first_slash);
+	else
+		return path;
+#else
+	auto first_slash = path.find_first_of('/');
+	if (first_slash != std::string::npos)
+		return path.substr(0, first_slash);
+	else
+		return path;
+#endif
+}
+
+std::string FilePath::remove_first_component(const std::string& path)
+{
+#ifdef WIN32
+	auto first_slash = path.find_first_of("/\\");
+	if (first_slash != std::string::npos)
+		return path.substr(first_slash + 1);
+	else
+		return std::string();
+#else
+	auto first_slash = path.find_first_of('/');
+	if (first_slash != std::string::npos)
+		return path.substr(first_slash + 1);
+	else
+		return std::string();
+#endif
+}
+
 std::string FilePath::last_component(const std::string &path)
 {
 #ifdef WIN32
@@ -409,27 +443,50 @@ std::string FilePath::remove_last_component(const std::string &path)
 
 std::string FilePath::combine(const std::string &path1, const std::string &path2)
 {
+	auto path1_conv = convert_path_delimiters(path1);
+	auto path2_conv = convert_path_delimiters(path2);
 #ifdef WIN32
-	if (path1.empty())
-		return path2;
-	else if (path2.empty())
-		return path1;
-	else if (path2.front() == '/' || path2.front() == '\\')
-		return path2;
-	else if (path1.back() != '/' && path1.back() != '\\')
-		return path1 + "\\" + path2;
+	if (path1_conv.empty())
+		return path2_conv;
+	else if (path2_conv.empty())
+		return path1_conv;
+	else if (path2_conv.front() == '/' || path2_conv.front() == '\\')
+		return path2_conv;
+	else if (path1_conv.back() != '/' && path1_conv.back() != '\\')
+		return path1_conv + "\\" + path2_conv;
 	else
-		return path1 + path2;
+		return path1_conv + path2_conv;
 #else
-	if (path1.empty())
+	if (path1_conv.empty())
+		return path2_conv;
+	else if (path2_conv.empty())
+		return path1_conv;
+	else if (path2_conv.front() == '/')
 		return path2;
-	else if (path2.empty())
-		return path1;
-	else if (path2.front() == '/')
-		return path2;
-	else if (path1.back() != '/')
-		return path1 + "/" + path2;
+	else if (path1_conv.back() != '/')
+		return path1_conv + "/" + path2_conv;
 	else
-		return path1 + path2;
+		return path1_conv + path2_conv;
 #endif
+}
+
+std::string FilePath::convert_path_delimiters(const std::string &path)
+{
+	std::string result = path;
+#ifdef WIN32
+	auto pos = result.find("/");
+	while (pos != std::string::npos)
+	{
+		result.replace(result.find("/"), 1, "\\");
+		pos = result.find("/");
+	}
+#else
+	auto pos = result.find("\\");
+	while (pos != std::string::npos)
+	{
+		result.replace(result.find("\\"), 1, "/");
+		pos = result.find("\\");
+	}
+#endif
+	return result;
 }

--- a/SurrealEngine/File.h
+++ b/SurrealEngine/File.h
@@ -70,7 +70,10 @@ public:
 	static bool has_extension(const std::string &filename, const char *extension);
 	static std::string extension(const std::string &filename);
 	static std::string remove_extension(const std::string &filename);
+	static std::string first_component(const std::string& path);
+	static std::string remove_first_component(const std::string& path);
 	static std::string last_component(const std::string &path);
 	static std::string remove_last_component(const std::string &path);
 	static std::string combine(const std::string &path1, const std::string &path2);
+	static std::string convert_path_delimiters(const std::string &path);
 };

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -73,6 +73,24 @@ bool IniFile::ReadLine(const std::string& text, size_t& pos, std::string& line)
 	return true;
 }
 
+std::vector<NameString> IniFile::GetKeys(NameString sectionName) const
+{
+	std::vector<NameString> result;
+	
+	auto itSection = sections.find(sectionName);
+	if (itSection == sections.end())
+		return {};
+
+	const auto& values = itSection->second;
+
+	for (auto& key : values)
+	{
+		result.push_back(key.first);
+	}
+
+	return result;
+}
+
 std::string IniFile::GetValue(NameString sectionName, NameString keyName) const
 {
 	auto itSection = sections.find(sectionName);

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -8,6 +8,7 @@ public:
 	IniFile() = default;
 	IniFile(const std::string& filename);
 
+	std::vector<NameString> GetKeys(NameString sectionName) const;
 	std::string GetValue(NameString sectionName, NameString keyName) const;
 	std::vector<std::string> GetValues(NameString sectionName, NameString keyName) const;
 

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -44,7 +44,9 @@ public:
 
 	UClass* FindClass(const NameString& name);
 
+	std::vector<NameString> GetIniKeysFromSection(NameString iniName, const NameString& sectionName);
 	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName);
+	std::vector<std::string> GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName);
 	std::string Localize(NameString packageName, const NameString& sectionName, const NameString& keyName);
 
 	std::vector<IntObject>& GetIntObjects(const NameString& metaclass);
@@ -52,11 +54,13 @@ public:
 
 private:
 	void LoadIntFiles();
+	void LoadPackageRemaps();
 	std::map<NameString, std::string> ParseIntPublicValue(const std::string& value);
 
 	void ScanForMaps();
 
-	void ScanFolder(const std::string& name, const std::string& search);
+	void ScanFolder(const std::string& packagedir, const std::string& search);
+	void ScanPaths();
 
 	void DelayLoadNow();
 
@@ -67,6 +71,7 @@ private:
 	std::map<NameString, std::unique_ptr<Package>> packages;
 	std::map<NameString, std::unique_ptr<IniFile>> iniFiles;
 	std::map<NameString, std::unique_ptr<IniFile>> intFiles;
+	std::map<std::string, std::string> packageRemaps;
 
 	std::map<NameString, std::vector<IntObject>> IntObjects;
 

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -23,6 +23,7 @@ public:
 	PackageManager(const GameLaunchInfo& launchInfo);
 
 	bool IsUnreal1() const { return launchInfo.gameName == "Unreal"; }
+	bool IsUnreal1_226() const { return IsUnreal1() && launchInfo.engineVersion == 226; }
 	bool IsUnreal1_227() const { return IsUnreal1() && launchInfo.engineVersion == 227; }
 	bool IsUnrealTournament() const { return launchInfo.gameName == "UnrealTournament"; }
 	bool IsUnrealTournament_469() const { return IsUnrealTournament() && launchInfo.engineVersion == 469; }

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -2,6 +2,7 @@
 
 #include "Package.h"
 #include "IniFile.h"
+#include "GameFolder.h"
 #include <list>
 
 class PackageStream;
@@ -19,10 +20,16 @@ struct IntObject
 class PackageManager
 {
 public:
-	PackageManager(const std::string& basepath, int engineVersion, const std::string& gameName);
+	PackageManager(const GameLaunchInfo& launchInfo);
 
-	bool IsUnreal1() const { return engineVersion < 300; }
-	int GetEngineVersion() const { return engineVersion; }
+	bool IsUnreal1() const { return launchInfo.gameName == "Unreal"; }
+	bool IsUnreal1_227() const { return IsUnreal1() && launchInfo.engineVersion == 227; }
+	bool IsUnrealTournament() const { return launchInfo.gameName == "UnrealTournament"; }
+	bool IsUnrealTournament_469() const { return IsUnrealTournament() && launchInfo.engineVersion == 469; }
+	bool IsDeusEx() const { return launchInfo.gameName == "DeusEx"; }
+
+	int GetEngineVersion() const { return launchInfo.engineVersion; }
+	int GetEngineSubVersion() const { return launchInfo.engineSubVersion; }
 
 	Package *GetPackage(const NameString& name);
 	std::vector<NameString> GetPackageNames() const;
@@ -55,7 +62,6 @@ private:
 	std::vector<UObject*> delayLoads;
 	int delayLoadActive = 0;
 
-	std::string basepath;
 	std::map<NameString, std::string> packageFilenames;
 	std::map<NameString, std::unique_ptr<Package>> packages;
 	std::map<NameString, std::unique_ptr<IniFile>> iniFiles;
@@ -73,8 +79,7 @@ private:
 
 	std::list<OpenStream> openStreams;
 
-	std::string gameName;
-	int engineVersion = 436;
+	GameLaunchInfo launchInfo;
 
 	friend class Package;
 	friend struct SetDelayLoadActive;

--- a/SurrealEngine/UObject/PropertyOffsets.cpp
+++ b/SurrealEngine/UObject/PropertyOffsets.cpp
@@ -2428,10 +2428,14 @@ static void InitPropertyOffsets_TcpLink(PackageManager* packages)
 		memset(&PropOffsets_TcpLink, 0xff, sizeof(PropOffsets_TcpLink));
 		return;
 	}
-	PropOffsets_TcpLink.AcceptClass = cls->GetProperty("AcceptClass")->DataOffset;
+
+	// AcceptClass and SendFIFO don't seem to exist in Unreal Gold 226 for some reason?
+	if (!packages->IsUnreal1_226())
+		PropOffsets_TcpLink.AcceptClass = cls->GetProperty("AcceptClass")->DataOffset;
 	PropOffsets_TcpLink.LinkState = cls->GetProperty("LinkState")->DataOffset;
 	PropOffsets_TcpLink.RemoteAddr = cls->GetProperty("RemoteAddr")->DataOffset;
-	PropOffsets_TcpLink.SendFIFO = cls->GetProperty("SendFIFO")->DataOffset;
+	if (!packages->IsUnreal1_226())
+		PropOffsets_TcpLink.SendFIFO = cls->GetProperty("SendFIFO")->DataOffset;
 }
 
 void InitPropertyOffsets(PackageManager* packages)


### PR DESCRIPTION
- PackageManager now uses GameLaunchInfo directly, and it has additional helper functions for checking which game we're running (IsDeusEx(), IsUnrealTournament(), etc.)
- PackageManager now uses the `Paths` keys inside the ini file for determining the paths it should check for packages. It also checks the `PackageRemap` keys when available, though I'm unsure about whether the remapping I'm doing is correct or not here.
- Disabled getting some properties of the TcpLink class when the game is Unreal Gold version 226, as they crashed the engine due to them apparently not existing. The game now launches on Linux (same caveats mentioned in readme apply), but crashes on Windows still for some reason.
- Additional functions are added into FilePath and IniFile classes for implementing the above changes.