### PR TITLE
Linux-focused FilePath and Directory changes

### DIFF
--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -259,7 +259,11 @@ std::vector<std::string> Directory::files(const std::string &filename)
 
 	DIR *dir = opendir(path.c_str());
 	if (!dir)
-		throw std::runtime_error("Could not open folder: " + path);
+	{
+		//throw std::runtime_error("Could not open folder: " + path);
+		printf("Could not open folder: %s\n", path.c_str());
+		return {};
+	}
 	
 	while (true)
 	{
@@ -375,70 +379,58 @@ std::string FilePath::remove_extension(const std::string &filename)
 
 std::string FilePath::first_component(const std::string& path)
 {
+	auto path_conv = convert_path_delimiters(path);
 #ifdef WIN32
-	auto first_slash = path.find_first_of("/\\");
-	if (first_slash != std::string::npos)
-		return path.substr(0, first_slash);
-	else
-		return path;
+	auto first_slash = path_conv.find_first_of("/\\");
 #else
-	auto first_slash = path.find_first_of('/');
-	if (first_slash != std::string::npos)
-		return path.substr(0, first_slash);
-	else
-		return path;
+	auto first_slash = path_conv.find_first_of('/');
 #endif
+	if (first_slash != std::string::npos)
+		return path_conv.substr(0, first_slash);
+	else
+		return path_conv;
 }
 
 std::string FilePath::remove_first_component(const std::string& path)
 {
+	auto path_conv = convert_path_delimiters(path);
 #ifdef WIN32
-	auto first_slash = path.find_first_of("/\\");
-	if (first_slash != std::string::npos)
-		return path.substr(first_slash + 1);
-	else
-		return std::string();
+	auto first_slash = path_conv.find_first_of("/\\");
 #else
-	auto first_slash = path.find_first_of('/');
+	auto first_slash = path_conv.find_first_of('/');
+#endif
 	if (first_slash != std::string::npos)
-		return path.substr(first_slash + 1);
+		return path_conv.substr(first_slash + 1);
 	else
 		return std::string();
-#endif
 }
 
 std::string FilePath::last_component(const std::string &path)
 {
+	auto path_conv = convert_path_delimiters(path);
 #ifdef WIN32
-	auto last_slash = path.find_last_of("/\\");
-	if (last_slash != std::string::npos)
-		return path.substr(last_slash + 1);
-	else
-		return path;
+	auto last_slash = path_conv.find_last_of("/\\");
 #else
-	auto last_slash = path.find_last_of('/');
-	if (last_slash != std::string::npos)
-		return path.substr(last_slash + 1);
-	else
-		return path;
+	auto last_slash = path_conv.find_last_of('/');
 #endif
+	if (last_slash != std::string::npos)
+		return path_conv.substr(last_slash + 1);
+	else
+		return path_conv;
 }
 
 std::string FilePath::remove_last_component(const std::string &path)
 {
+	auto path_conv = convert_path_delimiters(path);
 #ifdef WIN32
-	auto last_slash = path.find_last_of("/\\");
-	if (last_slash != std::string::npos)
-		return path.substr(0, last_slash);
-	else
-		return std::string();
+	auto last_slash = path_conv.find_last_of("/\\");
 #else
-	auto last_slash = path.find_last_of('/');
+	auto last_slash = path_conv.find_last_of('/');
+#endif
 	if (last_slash != std::string::npos)
-		return path.substr(0, last_slash);
+		return path_conv.substr(0, last_slash);
 	else
 		return std::string();
-#endif
 }
 
 std::string FilePath::combine(const std::string &path1, const std::string &path2)

--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -261,7 +261,7 @@ std::vector<std::string> Directory::files(const std::string &filename)
 	if (!dir)
 	{
 		//throw std::runtime_error("Could not open folder: " + path);
-		printf("Could not open folder: %s\n", path.c_str());
+		//printf("Could not open folder: %s\n", path.c_str());
 		return {};
 	}
 	


### PR DESCRIPTION
* FilePath: Make more functions convert the path delimiters first
* Directory::files(): Don't throw an exception on Linux when the directory does not exist, just print it to the console (UGold 226 has some Paths that does not really exist)

These two changes make UGold 226 run on Linux again. I had it working when the previous PR was only about not loading the properties that don't exist in there, but the later patches had borked it in a different manner.