### PR TITLE
Ini files saving, SurrealEngine-specific ini files and map detection improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,12 +193,12 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/Package/PackageFlags.h
 	SurrealEngine/Package/Package.cpp
 	SurrealEngine/Package/PackageManager.h
+	SurrealEngine/Package/PackageStream.h
 	SurrealEngine/Package/PackageStream.cpp
 	SurrealEngine/Package/IniFile.h
-	SurrealEngine/Package/PackageStream.h
 	SurrealEngine/Package/IniFile.cpp
-	SurrealEngine/Package/IniProperty.h
 	SurrealEngine/Package/IniProperty.cpp
+	SurrealEngine/Package/IniProperty.h
 	SurrealEngine/Package/NameString.cpp
 	SurrealEngine/Package/NameString.h
 	SurrealEngine/Math/FrustumPlanes.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,8 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/Package/IniFile.h
 	SurrealEngine/Package/PackageStream.h
 	SurrealEngine/Package/IniFile.cpp
+	SurrealEngine/Package/IniProperty.h
+	SurrealEngine/Package/IniProperty.cpp
 	SurrealEngine/Package/NameString.cpp
 	SurrealEngine/Package/NameString.h
 	SurrealEngine/Math/FrustumPlanes.h

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -189,6 +189,8 @@ void Engine::Run()
 
 	window->UnlockCursor();
 
+	packages->SaveAllIniFiles();
+
 	CloseWindow();
 }
 

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -226,7 +226,10 @@ void Engine::ClientTravel(const std::string& newURL, uint8_t travelType, bool tr
 UnrealURL Engine::GetDefaultURL(const std::string& map)
 {
 	UnrealURL url;
-	url.Map = map;
+	if (map.find_last_of("." + packages->GetMapExtension()) == std::string::npos)
+		url.Map = map + "." + packages->GetMapExtension();
+	else
+		url.Map = map;
 	for (std::string optionKey : { "Name", "Class", "team", "skin", "Face", "Voice", "OverrideClass" })
 	{
 		url.Options.push_back(optionKey + "=" + packages->GetIniValue("user", "DefaultPlayer", optionKey));
@@ -237,7 +240,7 @@ UnrealURL Engine::GetDefaultURL(const std::string& map)
 void Engine::LoadEntryMap()
 {
 	// The entry map is the map you see in the game when no other map is playing. For example when disconnected from a server. It is always loaded and running.
-	LoadMap(GetDefaultURL("Entry.unr"));
+	LoadMap(GetDefaultURL("Entry"));
 	EntryLevelInfo = LevelInfo;
 	EntryLevel = Level;
 	LevelInfo = nullptr;

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -845,9 +845,9 @@ void Engine::OpenWindow()
 	if (!window)
 		window = DisplayWindow::Create(this);
 
-	int width = client->StartupFullscreen ? client->FullscreenViewportX : client->WindowedViewportX;
-	int height = client->StartupFullscreen ? client->FullscreenViewportY : client->WindowedViewportY;
-	bool fullscreen = client->StartupFullscreen;
+	int width = client->StartupFullscreen.Value() ? client->FullscreenViewportX.Value() : client->WindowedViewportX.Value();
+	int height = client->StartupFullscreen.Value() ? client->FullscreenViewportY.Value() : client->WindowedViewportY.Value();
+	bool fullscreen = client->StartupFullscreen.Value();
 
 	window->SetWindowTitle("Unreal Tournament");
 	window->SetClientFrame(Rect::xywh(0.0, 0.0, width, height));

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -66,6 +66,17 @@ void Engine::Run()
 	LoadEngineSettings();
 	LoadKeybindings();
 
+	if (packages->MissingSESystemIni())
+	{
+		audiodev->LoadProperties("Galaxy.GalaxyAudioSubsystem");
+		renderdev->LoadProperties("D3DDrv.Direct3DRenderDevice");
+	}
+	else
+	{
+		audiodev->LoadProperties();
+		renderdev->LoadProperties();
+	}
+
 	OpenWindow();
 
 	audio = std::make_unique<AudioSubsystem>();
@@ -189,6 +200,8 @@ void Engine::Run()
 
 	window->UnlockCursor();
 
+	audiodev->SaveProperties();
+	renderdev->SaveProperties();
 	packages->SaveAllIniFiles();
 
 	CloseWindow();

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -66,17 +66,6 @@ void Engine::Run()
 	LoadEngineSettings();
 	LoadKeybindings();
 
-	if (packages->MissingSESystemIni())
-	{
-		audiodev->LoadProperties("Galaxy.GalaxyAudioSubsystem");
-		renderdev->LoadProperties("D3DDrv.Direct3DRenderDevice");
-	}
-	else
-	{
-		audiodev->LoadProperties();
-		renderdev->LoadProperties();
-	}
-
 	OpenWindow();
 
 	audio = std::make_unique<AudioSubsystem>();
@@ -200,6 +189,7 @@ void Engine::Run()
 
 	window->UnlockCursor();
 
+	client->SaveProperties();
 	audiodev->SaveProperties();
 	renderdev->SaveProperties();
 	packages->SaveAllIniFiles();
@@ -226,7 +216,7 @@ void Engine::ClientTravel(const std::string& newURL, uint8_t travelType, bool tr
 UnrealURL Engine::GetDefaultURL(const std::string& map)
 {
 	UnrealURL url;
-	if (map.find_last_of("." + packages->GetMapExtension()) == std::string::npos)
+	if (map.find("." + packages->GetMapExtension()) == std::string::npos)
 		url.Map = map + "." + packages->GetMapExtension();
 	else
 		url.Map = map;
@@ -778,12 +768,17 @@ std::vector<std::string> Engine::GetSubcommands(const std::string& command)
 
 void Engine::LoadEngineSettings()
 {
-	client->WindowedViewportX = std::stoi(packages->GetIniValue(LaunchInfo.gameName, "WinDrv.WindowsClient", "WindowedViewportX"));
-	client->WindowedViewportY = std::stoi(packages->GetIniValue(LaunchInfo.gameName, "WinDrv.WindowsClient", "WindowedViewportY"));
-	client->FullscreenViewportX = std::stoi(packages->GetIniValue(LaunchInfo.gameName, "WinDrv.WindowsClient", "FullscreenViewportX"));
-	client->FullscreenViewportY = std::stoi(packages->GetIniValue(LaunchInfo.gameName, "WinDrv.WindowsClient", "FullscreenViewportY"));
-	client->StartupFullscreen = packages->GetIniValue(LaunchInfo.gameName, "WinDrv.WindowsClient", "StartupFullscreen") == "True";
-	client->Brightness = std::stof(packages->GetIniValue(LaunchInfo.gameName, "WinDrv.WindowsClient", "Brightness"));
+	if (packages->MissingSESystemIni())
+	{
+		client->LoadProperties("WinDrv.WindowsClient");
+		audiodev->LoadProperties("Galaxy.GalaxyAudioSubsystem");
+		renderdev->LoadProperties("D3DDrv.Direct3DRenderDevice");
+		return;
+	}
+
+	client->LoadProperties();
+	audiodev->LoadProperties();
+	renderdev->LoadProperties();
 }
 
 void Engine::LoadKeybindings()

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -843,9 +843,9 @@ void Engine::OpenWindow()
 	if (!window)
 		window = DisplayWindow::Create(this);
 
-	int width = client->StartupFullscreen.Value() ? client->FullscreenViewportX.Value() : client->WindowedViewportX.Value();
-	int height = client->StartupFullscreen.Value() ? client->FullscreenViewportY.Value() : client->WindowedViewportY.Value();
-	bool fullscreen = client->StartupFullscreen.Value();
+	int width = client->StartupFullscreen ? client->FullscreenViewportX : client->WindowedViewportX;
+	int height = client->StartupFullscreen ? client->FullscreenViewportY : client->WindowedViewportY;
+	bool fullscreen = client->StartupFullscreen;
 
 	window->SetWindowTitle("Unreal Tournament");
 	window->SetClientFrame(Rect::xywh(0.0, 0.0, width, height));

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -121,3 +121,48 @@ std::vector<std::string> IniFile::GetValues(NameString sectionName, NameString k
 
 	return itValues->second;
 }
+
+void IniFile::SetValue(NameString sectionName, NameString keyName, const std::string& newValue)
+{
+	SetValues(sectionName, keyName, { newValue });
+}
+
+void IniFile::SetValues(NameString sectionName, NameString keyName, const std::vector<std::string>& newValues)
+{
+	sections[sectionName][keyName] = newValues;
+	isModified = true;
+}
+
+void IniFile::SaveTo(const std::string& filename)
+{
+	if (!isModified)
+		return;
+	
+	std::string ini_text = "";
+
+	// Start with sections first
+	for (auto& section : sections)
+	{
+		// Section header (i.e. [Engine.Engine])
+		std::string section_text = "[" + section.first.ToString() + "]\n";
+
+		// key=value pairs
+		for (auto& entry : section.second)
+		{
+			// a key can hold multiple values, like
+			// Paths=path1
+			// Paths=path2
+			// and so on, hence this loop
+			for (auto& value : entry.second)
+			{
+				section_text = entry.first.ToString() + "=" + value + "\n";
+			}
+		}
+
+		ini_text += section_text;
+	}
+
+	// Overwrite whatever is there
+	File::write_all_text(filename, ini_text);
+	isModified = false;
+}

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -43,6 +43,8 @@ IniFile::IniFile(const std::string& filename)
 			}
 		}
 	}
+
+	ini_file_path = filename;
 }
 
 bool IniFile::ReadLine(const std::string& text, size_t& pos, std::string& line)
@@ -133,9 +135,14 @@ void IniFile::SetValues(NameString sectionName, NameString keyName, const std::v
 	isModified = true;
 }
 
+void IniFile::SaveTo()
+{
+	SaveTo(ini_file_path);
+}
+
 void IniFile::SaveTo(const std::string& filename)
 {
-	if (!isModified)
+	if (filename == ini_file_path && !isModified)
 		return;
 	
 	std::string ini_text = "";
@@ -155,14 +162,18 @@ void IniFile::SaveTo(const std::string& filename)
 			// and so on, hence this loop
 			for (auto& value : entry.second)
 			{
-				section_text = entry.first.ToString() + "=" + value + "\n";
+				section_text += entry.first.ToString() + "=" + value + "\n";
 			}
 		}
 
-		ini_text += section_text;
+		ini_text += section_text + "\n";
 	}
 
 	// Overwrite whatever is there
 	File::write_all_text(filename, ini_text);
+
+	if (filename != ini_file_path)
+		ini_file_path = filename;
+
 	isModified = false;
 }

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -93,33 +93,33 @@ std::vector<NameString> IniFile::GetKeys(NameString sectionName) const
 	return result;
 }
 
-std::string IniFile::GetValue(NameString sectionName, NameString keyName) const
+std::string IniFile::GetValue(NameString sectionName, NameString keyName, std::string default_value) const
 {
 	auto itSection = sections.find(sectionName);
 	if (itSection == sections.end())
-		return {};
+		return default_value;
 
 	const auto& values = itSection->second;
 	auto itValues = values.find(keyName);
 	if (itValues == values.end())
-		return {};
+		return default_value;
 
 	if (itValues->second.empty())
-		return {};
+		return default_value;
 
 	return itValues->second.front();
 }
 
-std::vector<std::string> IniFile::GetValues(NameString sectionName, NameString keyName) const
+std::vector<std::string> IniFile::GetValues(NameString sectionName, NameString keyName, std::vector<std::string> default_values) const
 {
 	auto itSection = sections.find(sectionName);
 	if (itSection == sections.end())
-		return {};
+		return default_values;
 
 	const auto& values = itSection->second;
 	auto itValues = values.find(keyName);
 	if (itValues == values.end())
-		return {};
+		return default_values;
 
 	return itValues->second;
 }
@@ -131,6 +131,11 @@ void IniFile::SetValue(NameString sectionName, NameString keyName, const std::st
 
 void IniFile::SetValues(NameString sectionName, NameString keyName, const std::vector<std::string>& newValues)
 {
+	auto& oldValues = sections[sectionName][keyName];
+
+	if (oldValues == newValues)
+		return;
+	
 	sections[sectionName][keyName] = newValues;
 	isModified = true;
 }

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -47,6 +47,12 @@ IniFile::IniFile(const std::string& filename)
 	ini_file_path = filename;
 }
 
+IniFile::IniFile(const IniFile& other)
+{
+	ini_file_path = other.ini_file_path;
+	sections = other.sections;
+}
+
 bool IniFile::ReadLine(const std::string& text, size_t& pos, std::string& line)
 {
 	// Skip whitespace

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -8,12 +8,20 @@ public:
 	IniFile() = default;
 	IniFile(const std::string& filename);
 
+	bool IsModified() const { return isModified; }
+
 	std::vector<NameString> GetKeys(NameString sectionName) const;
 	std::string GetValue(NameString sectionName, NameString keyName) const;
 	std::vector<std::string> GetValues(NameString sectionName, NameString keyName) const;
 
+	void SetValue(NameString sectionName, NameString keyName, const std::string& newValue);
+	void SetValues(NameString sectionName, NameString keyName, const std::vector<std::string>& newValues);
+
+	void SaveTo(const std::string& filename);
+
 private:
 	bool ReadLine(const std::string& text, size_t& pos, std::string& line);
 
+	bool isModified = false;
 	std::map<NameString, std::map<NameString, std::vector<std::string>>> sections;
 };

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "NameString.h"
+#include <map>
 
 class IniFile
 {
 public:
 	IniFile() = default;
 	IniFile(const std::string& filename);
+	IniFile(const IniFile& other);
 
 	bool IsModified() const { return isModified; }
 

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -17,11 +17,16 @@ public:
 	void SetValue(NameString sectionName, NameString keyName, const std::string& newValue);
 	void SetValues(NameString sectionName, NameString keyName, const std::vector<std::string>& newValues);
 
-	void SaveTo(const std::string& filename);
+	// Saves values to the ini file the said values are loaded from
+	void SaveTo();
+	// Saves values to a specified file
+	void SaveTo(const std::string& filename); 
 
 private:
 	bool ReadLine(const std::string& text, size_t& pos, std::string& line);
 
 	bool isModified = false;
+
+	std::string ini_file_path;
 	std::map<NameString, std::map<NameString, std::vector<std::string>>> sections;
 };

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -11,8 +11,8 @@ public:
 	bool IsModified() const { return isModified; }
 
 	std::vector<NameString> GetKeys(NameString sectionName) const;
-	std::string GetValue(NameString sectionName, NameString keyName) const;
-	std::vector<std::string> GetValues(NameString sectionName, NameString keyName) const;
+	std::string GetValue(NameString sectionName, NameString keyName, std::string default_value="") const;
+	std::vector<std::string> GetValues(NameString sectionName, NameString keyName, std::vector<std::string> default_values = {}) const;
 
 	void SetValue(NameString sectionName, NameString keyName, const std::string& newValue);
 	void SetValues(NameString sectionName, NameString keyName, const std::vector<std::string>& newValues);

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -1,0 +1,56 @@
+#include "IniProperty.h"
+#include <stdexcept>
+
+template<> void IniProperty<float>::FromString(const std::string& valueString)
+{
+	if (valueString.empty())
+		throw std::runtime_error("Empty value received. Expected: float");
+	
+	value = std::stof(valueString);
+}
+
+template<> void IniProperty<int>::FromString(const std::string& valueString)
+{
+	if (valueString.empty())
+		throw std::runtime_error("Empty value received. Expected: int");
+
+	value = std::stoi(valueString);
+}
+
+template<> void IniProperty<uint8_t>::FromString(const std::string& valueString)
+{
+	if (valueString.empty())
+		throw std::runtime_error("Empty value received. Expected: uint8");
+
+	value = std::stoi(valueString);
+}
+
+
+template<> void IniProperty<std::string>::FromString(const std::string& valueString)
+{
+	// Lmao
+	value = valueString;
+}
+
+template<> std::string IniProperty<std::string>::ToString() const
+{
+	return Value();
+}
+
+template<> void IniProperty<bool>::FromString(const std::string& valueString)
+{
+	if (valueString.empty())
+		throw std::runtime_error("Empty value received. Expected: boolean");
+
+	if (valueString == "True" || valueString == "true")
+		value = true;
+	else if (valueString == "False" || valueString == "false")
+		value = false;
+	else
+		throw std::runtime_error("Received a non-boolean value: " + valueString);
+}
+
+template<> std::string IniProperty<bool>::ToString() const
+{
+	return value ? "True" : "False";
+}

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -25,16 +25,10 @@ template<> void IniProperty<uint8_t>::FromString(const std::string& valueString)
 	value = std::stoi(valueString);
 }
 
-
 template<> void IniProperty<std::string>::FromString(const std::string& valueString)
 {
 	// Lmao
 	value = valueString;
-}
-
-template<> std::string IniProperty<std::string>::ToString() const
-{
-	return Value();
 }
 
 template<> void IniProperty<bool>::FromString(const std::string& valueString)

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -1,49 +1,38 @@
 #include "IniProperty.h"
 #include <stdexcept>
 
-template<typename T> void IniProperty<T>::FromString(const std::string& valueString)
+template<>
+int IniPropertyConverter<int>::FromString(const std::string& valueString)
 {
+	return std::stoi(valueString);
 }
 
-template<> void IniProperty<float>::FromString(const std::string& valueString)
+template<>
+float IniPropertyConverter<float>::FromString(const std::string& valueString)
 {
-	if (valueString.empty())
-		throw std::runtime_error("Empty value received. Expected: float");
-
-	value = std::stof(valueString);
+	return std::stof(valueString);
 }
 
-template<> void IniProperty<int>::FromString(const std::string& valueString)
+template<>
+uint8_t IniPropertyConverter<uint8_t>::FromString(const std::string& valueString)
 {
-	if (valueString.empty())
-		throw std::runtime_error("Empty value received. Expected: int");
-
-	value = std::stoi(valueString);
+	return (uint8_t)std::stoul(valueString);
 }
 
-template<> void IniProperty<uint8_t>::FromString(const std::string& valueString)
+template<>
+bool IniPropertyConverter<bool>::FromString(const std::string& valueString)
 {
-	if (valueString.empty())
-		throw std::runtime_error("Empty value received. Expected: uint8");
-
-	value = std::stoi(valueString);
-}
-
-template<> void IniProperty<std::string>::FromString(const std::string& valueString)
-{
-	// Lmao
-	value = valueString;
-}
-
-template<> void IniProperty<bool>::FromString(const std::string& valueString)
-{
-	if (valueString.empty())
-		throw std::runtime_error("Empty value received. Expected: boolean");
-
 	if (valueString == "True" || valueString == "true" || valueString == "1")
-		value = true;
+		return true;
 	else if (valueString == "False" || valueString == "false" || valueString == "0")
-		value = false;
+		return false;
 	else
-		throw std::runtime_error("Received a non-boolean value: " + valueString);
+		throw std::runtime_error("Encountered non-boolean value: " + valueString);
 }
+
+template<>
+std::string IniPropertyConverter<std::string>::FromString(const std::string& valueString)
+{
+	return valueString;
+}
+

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -1,11 +1,15 @@
 #include "IniProperty.h"
 #include <stdexcept>
 
+template<typename T> void IniProperty<T>::FromString(const std::string& valueString)
+{
+}
+
 template<> void IniProperty<float>::FromString(const std::string& valueString)
 {
 	if (valueString.empty())
 		throw std::runtime_error("Empty value received. Expected: float");
-	
+
 	value = std::stof(valueString);
 }
 
@@ -36,15 +40,10 @@ template<> void IniProperty<bool>::FromString(const std::string& valueString)
 	if (valueString.empty())
 		throw std::runtime_error("Empty value received. Expected: boolean");
 
-	if (valueString == "True" || valueString == "true")
+	if (valueString == "True" || valueString == "true" || valueString == "1")
 		value = true;
-	else if (valueString == "False" || valueString == "false")
+	else if (valueString == "False" || valueString == "false" || valueString == "0")
 		value = false;
 	else
 		throw std::runtime_error("Received a non-boolean value: " + valueString);
-}
-
-template<> std::string IniProperty<bool>::ToString() const
-{
-	return value ? "True" : "False";
 }

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include "IniFile.h"
+
+template <typename T>
+class IniProperty
+{
+public:
+	T Value() const { return value; }
+	void FromString(const std::string& valueString);
+	void FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
+	{
+		FromString(iniFile.GetValue(section, keyName, std::to_string(value)));
+	}
+
+	IniProperty(T value) : value(value) {}
+	IniProperty(T& value) : value(value) {}
+	IniProperty(const std::string& valueString) { FromString(valueString); }
+	IniProperty(const IniFile& iniFile, const NameString& section, const NameString& keyName) { FromIniFile(iniFile, section, keyName); }
+
+	std::string ToString() const { return std::to_string(value); }
+
+	void operator=(const T& other) { value = other; }
+	bool operator==(const T& other) const { return value == other; }
+	bool operator!=(const T& other) const { return value != other; }
+
+private:
+	T value;
+};

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "IniFile.h"
 
 template <typename T>
@@ -16,7 +17,7 @@ public:
 	void FromString(const std::string& valueString);
 	void FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
 	{
-		FromString(iniFile.GetValue(section, keyName, std::to_string(value)));
+		FromString(iniFile.GetValue(section, keyName, ToString()));
 	}
 
 	std::string ToString() const { return std::to_string(value); }
@@ -29,3 +30,8 @@ public:
 private:
 	T value;
 };
+
+template<> std::string IniProperty<bool>::ToString() const 
+{
+	return value ? "True" : "False";
+}

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -5,38 +5,16 @@
 #include "IniFile.h"
 
 template <typename T>
-class IniProperty
+class IniPropertyConverter
 {
 public:
-	IniProperty(T& value) : value(value) {}
-	IniProperty(T&& value) : value(value) {}
-	IniProperty(const std::string& valueString) { FromString(valueString); }
-	IniProperty(const IniFile& iniFile, const NameString& section, const NameString& keyName) { FromIniFile(iniFile, section, keyName); }
-
-	T Value() const { return value; }
-	void FromString(const std::string& valueString);
-	void FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
+	static std::string ToString(const T& value) { return std::to_string(value); }
+	static T FromString(const std::string& valueString);
+	static T FromString(const char* valueString) { return FromString(std::string(valueString)); }
+	static T FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
 	{
-		FromString(iniFile.GetValue(section, keyName, ToString()));
+		return FromString(iniFile.GetValue(section, keyName));
 	}
 
-	std::string ToString() const { return std::to_string(value); }
-
-	void operator=(const T& other) { value = other; }
-	bool operator==(const T& other) const { return value == other; }
-	bool operator!=(const T& other) const { return value != other; }
-	bool operator!() const { return !value; }
-
-private:
-	T value;
+	IniPropertyConverter() = delete;
 };
-
-template<> std::string IniProperty<bool>::ToString() const 
-{
-	return value ? "True" : "False";
-}
-
-template<> void IniProperty<std::string>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
-{
-	value = iniFile.GetValue(section, keyName, value);
-}

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -35,3 +35,8 @@ template<> std::string IniProperty<bool>::ToString() const
 {
 	return value ? "True" : "False";
 }
+
+template<> void IniProperty<std::string>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
+{
+	value = iniFile.GetValue(section, keyName, value);
+}

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -7,6 +7,11 @@ template <typename T>
 class IniProperty
 {
 public:
+	IniProperty(T& value) : value(value) {}
+	IniProperty(T&& value) : value(value) {}
+	IniProperty(const std::string& valueString) { FromString(valueString); }
+	IniProperty(const IniFile& iniFile, const NameString& section, const NameString& keyName) { FromIniFile(iniFile, section, keyName); }
+
 	T Value() const { return value; }
 	void FromString(const std::string& valueString);
 	void FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
@@ -14,16 +19,12 @@ public:
 		FromString(iniFile.GetValue(section, keyName, std::to_string(value)));
 	}
 
-	IniProperty(T value) : value(value) {}
-	IniProperty(T& value) : value(value) {}
-	IniProperty(const std::string& valueString) { FromString(valueString); }
-	IniProperty(const IniFile& iniFile, const NameString& section, const NameString& keyName) { FromIniFile(iniFile, section, keyName); }
-
 	std::string ToString() const { return std::to_string(value); }
 
 	void operator=(const T& other) { value = other; }
 	bool operator==(const T& other) const { return value == other; }
 	bool operator!=(const T& other) const { return value != other; }
+	bool operator!() const { return !value; }
 
 private:
 	T value;

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -185,7 +185,7 @@ void PackageManager::ScanPaths()
 		// Combine everything
 		auto final_path = FilePath::combine(resulting_root_path, current_path);
 
-		// Do not add maps as packages, scan them separately instead
+		// Add map folders in a separate list, so ScanForMaps() can use them
 		if (filename == "*." + mapExtension)
 		{
 			mapFolders.push_back(final_path);

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -287,7 +287,7 @@ std::vector<NameString> PackageManager::GetIniKeysFromSection(NameString iniName
 	return ini->GetKeys(sectionName);
 }
 
-std::string PackageManager::GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName)
+std::string PackageManager::GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, std::string default_value)
 {
 	if (iniName == "system" || iniName == "System")
 		iniName = launchInfo.gameName;
@@ -300,10 +300,10 @@ std::string PackageManager::GetIniValue(NameString iniName, const NameString& se
 		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.folder, "System/" + iniName.ToString() + ".ini"));
 	}
 
-	return ini->GetValue(sectionName, keyName);
+	return ini->GetValue(sectionName, keyName, default_value);
 }
 
-std::vector<std::string> PackageManager::GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName)
+std::vector<std::string> PackageManager::GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, std::vector<std::string> default_values)
 {
 	if (iniName == "system" || iniName == "System")
 		iniName = launchInfo.gameName;
@@ -316,7 +316,7 @@ std::vector<std::string> PackageManager::GetIniValues(NameString iniName, const 
 		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.folder, "System/" + iniName.ToString() + ".ini"));
 	}
 
-	return ini->GetValues(sectionName, keyName);
+	return ini->GetValues(sectionName, keyName, default_values);
 }
 
 void PackageManager::SetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::string& newValue)
@@ -379,7 +379,11 @@ void PackageManager::LoadEngineIniFiles()
 	const std::string system_folder = FilePath::combine(launchInfo.folder, "System");
 
 	if (!File::try_open_existing(FilePath::combine(system_folder, engine_ini_name)))
+	{
+		missing_se_system_ini = true;
 		engine_ini_name = engine_ini_name.substr(3); // Trim off the "SE-" part
+	}
+		
 	iniFiles[launchInfo.gameName] = std::make_unique<IniFile>(FilePath::combine(system_folder, engine_ini_name));
 
 	if (!File::try_open_existing(FilePath::combine(system_folder, user_ini_name)))

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -354,7 +354,7 @@ void PackageManager::SaveAllIniFiles()
 		else if (iniFile.first == "User")
 			iniFile.second->SaveTo(FilePath::combine(system_folder, "SE-User.ini"));
 		else
-			iniFile.second->SaveTo(FilePath::combine(system_folder, iniFile.first.ToString() + ".ini"));
+			iniFile.second->SaveTo();
 	}
 }
 

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -271,6 +271,16 @@ UClass* PackageManager::FindClass(const NameString& name)
 	}
 }
 
+std::unique_ptr<IniFile> PackageManager::GetIniFile(NameString iniName)
+{
+	if (iniName == "system" || iniName == "System")
+		iniName = launchInfo.gameName;
+	else if (iniName == "user")
+		iniName = "User";
+
+	return std::make_unique<IniFile>(*iniFiles[iniName]);
+}
+
 std::vector<NameString> PackageManager::GetIniKeysFromSection(NameString iniName, const NameString& sectionName)
 {
 	if (iniName == "system" || iniName == "System")

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -44,6 +44,7 @@ public:
 
 	UClass* FindClass(const NameString& name);
 
+	std::unique_ptr<IniFile> GetIniFile(NameString iniName);
 	std::vector<NameString> GetIniKeysFromSection(NameString iniName, const NameString& sectionName);
 	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, std::string default_value = "");
 	std::vector<std::string> GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, std::vector<std::string> default_values = {});

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -44,6 +44,8 @@ public:
 
 	UClass* FindClass(const NameString& name);
 
+	std::string GetMapExtension() { return mapExtension; }
+
 	std::unique_ptr<IniFile> GetIniFile(NameString iniName);
 	std::vector<NameString> GetIniKeysFromSection(NameString iniName, const NameString& sectionName);
 	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, std::string default_value = "");
@@ -83,7 +85,11 @@ private:
 
 	std::map<NameString, std::vector<IntObject>> IntObjects;
 
+	std::vector<std::string> mapFolders;
 	std::vector<std::string> maps;
+
+	std::string mapExtension;
+	std::string saveExtension;
 
 	bool missing_se_system_ini = false;
 

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -45,8 +45,8 @@ public:
 	UClass* FindClass(const NameString& name);
 
 	std::vector<NameString> GetIniKeysFromSection(NameString iniName, const NameString& sectionName);
-	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName);
-	std::vector<std::string> GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName);
+	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, std::string default_value = "");
+	std::vector<std::string> GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, std::vector<std::string> default_values = {});
 	void SetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::string& newValue);
 	void SetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::vector<std::string>& newValues);
 	void SaveAllIniFiles();
@@ -55,6 +55,8 @@ public:
 
 	std::vector<IntObject>& GetIntObjects(const NameString& metaclass);
 	const std::vector<std::string>& GetMaps() const { return maps; }
+
+	bool MissingSESystemIni() const { return missing_se_system_ini; }
 
 private:
 	void LoadEngineIniFiles();
@@ -81,6 +83,8 @@ private:
 	std::map<NameString, std::vector<IntObject>> IntObjects;
 
 	std::vector<std::string> maps;
+
+	bool missing_se_system_ini = false;
 
 	struct OpenStream
 	{

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -47,12 +47,17 @@ public:
 	std::vector<NameString> GetIniKeysFromSection(NameString iniName, const NameString& sectionName);
 	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName);
 	std::vector<std::string> GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName);
+	void SetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::string& newValue);
+	void SetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::vector<std::string>& newValues);
+	void SaveAllIniFiles();
+
 	std::string Localize(NameString packageName, const NameString& sectionName, const NameString& keyName);
 
 	std::vector<IntObject>& GetIntObjects(const NameString& metaclass);
 	const std::vector<std::string>& GetMaps() const { return maps; }
 
 private:
+	void LoadEngineIniFiles();
 	void LoadIntFiles();
 	void LoadPackageRemaps();
 	std::map<NameString, std::string> ParseIntPublicValue(const std::string& value);

--- a/SurrealEngine/Render/RenderSubsystem.cpp
+++ b/SurrealEngine/Render/RenderSubsystem.cpp
@@ -29,7 +29,7 @@ void RenderSubsystem::DrawGame(float levelTimeElapsed)
 		flashFog = player->FlashFog();
 	}
 
-	Device->Brightness = engine->client->Brightness;
+	Device->Brightness = engine->client->Brightness.Value();
 	Device->Lock(vec4(flashScale, 1.0f), vec4(flashFog, 1.0f), vec4(0.0f));
 
 	ResetCanvas();
@@ -49,7 +49,7 @@ void RenderSubsystem::DrawGame(float levelTimeElapsed)
 
 void RenderSubsystem::DrawEditorViewport()
 {
-	Device->Brightness = engine->client->Brightness;
+	Device->Brightness = engine->client->Brightness.Value();
 	DrawScene();
 }
 

--- a/SurrealEngine/Render/RenderSubsystem.cpp
+++ b/SurrealEngine/Render/RenderSubsystem.cpp
@@ -29,7 +29,7 @@ void RenderSubsystem::DrawGame(float levelTimeElapsed)
 		flashFog = player->FlashFog();
 	}
 
-	Device->Brightness = engine->client->Brightness.Value();
+	Device->Brightness = engine->client->Brightness;
 	Device->Lock(vec4(flashScale, 1.0f), vec4(flashFog, 1.0f), vec4(0.0f));
 
 	ResetCanvas();
@@ -49,7 +49,7 @@ void RenderSubsystem::DrawGame(float levelTimeElapsed)
 
 void RenderSubsystem::DrawEditorViewport()
 {
-	Device->Brightness = engine->client->Brightness.Value();
+	Device->Brightness = engine->client->Brightness;
 	DrawScene();
 }
 

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -9,15 +9,15 @@ std::string USurrealRenderDevice::GetPropertyAsString(const NameString& property
 	if (propertyName == "Class")
 		return "class'" + Class + "'";
 	if (propertyName == "Translucency")
-		return Translucency.ToString();
+		return IniPropertyConverter<bool>::ToString(Translucency);
 	else if (propertyName == "VolumetricLighting")
-		return VolumetricLighting.ToString();
+		return IniPropertyConverter<bool>::ToString(VolumetricLighting);
 	else if (propertyName == "ShinySurfaces")
-		return ShinySurfaces.ToString();
+		return IniPropertyConverter<bool>::ToString(ShinySurfaces);
 	else if (propertyName == "Coronas")
-		return Coronas.ToString();
+		return IniPropertyConverter<bool>::ToString(Coronas);
 	else if (propertyName == "HighDetailActors")
-		return HighDetailActors.ToString();
+		return IniPropertyConverter<bool>::ToString(HighDetailActors);
 
 	engine->LogMessage("Queried unknown property for SurrealRenderDevice: " + propertyName.ToString());
 	return {};
@@ -26,15 +26,15 @@ std::string USurrealRenderDevice::GetPropertyAsString(const NameString& property
 void USurrealRenderDevice::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	if (propertyName == "Translucency")
-		Translucency.FromString(value);
+		Translucency = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "VolumetricLighting")
-		VolumetricLighting.FromString(value);
+		VolumetricLighting = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "ShinySurfaces")
-		ShinySurfaces.FromString(value);
+		ShinySurfaces = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "Coronas")
-		Coronas.FromString(value);
+		Coronas = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "HighDetailActors")
-		HighDetailActors.FromString(value);
+		HighDetailActors = IniPropertyConverter<bool>::FromString(value);
 	else
 		engine->LogMessage("Setting unknown property for SurrealRenderDevice: " + propertyName.ToString());
 
@@ -48,20 +48,20 @@ void USurrealRenderDevice::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	Translucency.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Translucency");
-	VolumetricLighting.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "VolumetricLighting");
-	ShinySurfaces.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ShinySurfaces");
-	Coronas.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Coronas");
-	HighDetailActors.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "HighDetailActors");
+	Translucency = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Translucency");
+	VolumetricLighting = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "VolumetricLighting");
+	ShinySurfaces = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ShinySurfaces");
+	Coronas = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Coronas");
+	HighDetailActors = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "HighDetailActors");
 }
 
 void USurrealRenderDevice::SaveProperties()
 {
-	engine->packages->SetIniValue("System", Class, "Translucency", Translucency.ToString());
-	engine->packages->SetIniValue("System", Class, "VolumetricLighting", VolumetricLighting.ToString());
-	engine->packages->SetIniValue("System", Class, "ShinySurfaces", ShinySurfaces.ToString());
-	engine->packages->SetIniValue("System", Class, "Coronas", Coronas.ToString());
-	engine->packages->SetIniValue("System", Class, "HighDetailActors", HighDetailActors.ToString());
+	engine->packages->SetIniValue("System", Class, "Translucency", IniPropertyConverter<bool>::ToString(Translucency));
+	engine->packages->SetIniValue("System", Class, "VolumetricLighting", IniPropertyConverter<bool>::ToString(VolumetricLighting));
+	engine->packages->SetIniValue("System", Class, "ShinySurfaces", IniPropertyConverter<bool>::ToString(ShinySurfaces));
+	engine->packages->SetIniValue("System", Class, "Coronas", IniPropertyConverter<bool>::ToString(Coronas));
+	engine->packages->SetIniValue("System", Class, "HighDetailActors", IniPropertyConverter<bool>::ToString(HighDetailActors));
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -71,37 +71,37 @@ std::string USurrealAudioDevice::GetPropertyAsString(const NameString& propertyN
 	if (propertyName == "Class")
 		return "class'" + Class + "'";
 	else if (propertyName == "UseFilter")
-		return UseFilter.ToString();
+		return IniPropertyConverter<bool>::ToString(UseFilter);
 	else if (propertyName == "UseSurround")
-		return UseSurround.ToString();
+		return IniPropertyConverter<bool>::ToString(UseSurround);
 	else if (propertyName == "UseStereo")
-		return UseStereo.ToString();
+		return IniPropertyConverter<bool>::ToString(UseStereo);
 	else if (propertyName == "UseCDMusic")
-		return UseCDMusic.ToString();
+		return IniPropertyConverter<bool>::ToString(UseCDMusic);
 	else if (propertyName == "UseDigitalMusic")
-		return UseDigitalMusic.ToString();
+		return IniPropertyConverter<bool>::ToString(UseDigitalMusic);
 	else if (propertyName == "UseSpatial")
-		return UseSpatial.ToString();
+		return IniPropertyConverter<bool>::ToString(UseSpatial);
 	else if (propertyName == "UseReverb")
-		return UseReverb.ToString();
+		return IniPropertyConverter<bool>::ToString(UseReverb);
 	else if (propertyName == "Use3dHardware")
-		return Use3dHardware.ToString();
+		return IniPropertyConverter<bool>::ToString(Use3dHardware);
 	else if (propertyName == "LowSoundQuality")
-		return LowSoundQuality.ToString();
+		return IniPropertyConverter<bool>::ToString(LowSoundQuality);
 	else if (propertyName == "ReverseStereo")
-		return ReverseStereo.ToString();
+		return IniPropertyConverter<bool>::ToString(ReverseStereo);
 	else if (propertyName == "Latency")
-		return Latency.ToString();
+		return IniPropertyConverter<int>::ToString(Latency);
 	else if (propertyName == "OutputRate")
-		return OutputRate.ToString();
+		return IniPropertyConverter<int>::ToString(OutputRate);
 	else if (propertyName == "Channels")
-		return Channels.ToString();
+		return IniPropertyConverter<int>::ToString(Channels);
 	else if (propertyName == "MusicVolume")
-		return MusicVolume.ToString();
+		return IniPropertyConverter<uint8_t>::ToString(MusicVolume);
 	else if (propertyName == "SoundVolume")
-		return SoundVolume.ToString();
+		return IniPropertyConverter<uint8_t>::ToString(SoundVolume);
 	else if (propertyName == "AmbientFactor")
-		return AmbientFactor.ToString();
+		return IniPropertyConverter<float>::ToString(AmbientFactor);
 
 	engine->LogMessage("Queried unknown property for SurrealAudioDevice: " + propertyName.ToString());
 	return {};
@@ -110,37 +110,37 @@ std::string USurrealAudioDevice::GetPropertyAsString(const NameString& propertyN
 void USurrealAudioDevice::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	if (propertyName == "UseFilter")
-		UseFilter.FromString(value);
+		UseFilter = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseSurround")
-		UseSurround.FromString(value);
+		UseSurround = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseStereo")
-		UseStereo.FromString(value);
+		UseStereo = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseCDMusic")
-		UseCDMusic.FromString(value);
+		UseCDMusic = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseDigitalMusic")
-		UseDigitalMusic.FromString(value);
+		UseDigitalMusic = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseSpatial")
-		UseSpatial.FromString(value);
+		UseSpatial = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseReverb")
-		UseReverb.FromString(value);
+		UseReverb = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "Use3dHardware")
-		Use3dHardware.FromString(value);
+		Use3dHardware = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "LowSoundQuality")
-		LowSoundQuality.FromString(value);
+		LowSoundQuality = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "ReverseStereo")
-		ReverseStereo.FromString(value);
+		ReverseStereo = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "Latency")
-		Latency.FromString(value);
+		Latency = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "OutputRate")
-		OutputRate.FromString(value);
+		OutputRate = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "Channels")
-		Channels.FromString(value);
+		Channels = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "MusicVolume")
-		MusicVolume.FromString(value);
+		MusicVolume = IniPropertyConverter<uint8_t>::FromString(value);
 	else if (propertyName == "SoundVolume")
-		SoundVolume.FromString(value);
+		SoundVolume = IniPropertyConverter<uint8_t>::FromString(value);
 	else if (propertyName == "AmbientFactor")
-		AmbientFactor.FromString(value);
+		AmbientFactor = IniPropertyConverter<float>::FromString(value);
 	else
 		engine->LogMessage("Setting unknown property for SurrealAudioDevice: " + propertyName.ToString());
 
@@ -154,42 +154,42 @@ void USurrealAudioDevice::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	UseFilter.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseFilter");
-	UseSurround.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSurround");
-	UseStereo.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseStereo");
-	UseCDMusic.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseCDMusic");
-	UseDigitalMusic.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDigitalMusic");
-	UseSpatial.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSpatial");
-	UseReverb.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseReverb");
-	Use3dHardware.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Use3dHardware");
-	LowSoundQuality.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "LowSoundQuality");
-	ReverseStereo.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ReverseStereo");
-	Latency.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Latency");
-	OutputRate.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "OutputRate");
-	Channels.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Channels");
-	MusicVolume.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MusicVolume");
-	SoundVolume.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SoundVolume");
-	AmbientFactor.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor");
+	UseFilter = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseFilter");
+	UseSurround = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSurround");
+	UseStereo = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseStereo");
+	UseCDMusic = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseCDMusic");
+	UseDigitalMusic = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDigitalMusic");
+	UseSpatial = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSpatial");
+	UseReverb = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseReverb");
+	Use3dHardware = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Use3dHardware");
+	LowSoundQuality = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "LowSoundQuality");
+	ReverseStereo = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ReverseStereo");
+	Latency = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Latency");
+	OutputRate = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "OutputRate");
+	Channels = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Channels");
+	MusicVolume = IniPropertyConverter<uint8_t>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MusicVolume");
+	SoundVolume = IniPropertyConverter<uint8_t>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SoundVolume");
+	AmbientFactor = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor");
 }
 
 void USurrealAudioDevice::SaveProperties()
 {
-	engine->packages->SetIniValue("System", Class, "UseFilter", UseFilter.ToString());
-	engine->packages->SetIniValue("System", Class, "UseSurround", UseSurround.ToString());
-	engine->packages->SetIniValue("System", Class, "UseStereo", UseStereo.ToString());
-	engine->packages->SetIniValue("System", Class, "UseCDMusic", UseCDMusic.ToString());
-	engine->packages->SetIniValue("System", Class, "UseDigitalMusic", UseDigitalMusic.ToString());
-	engine->packages->SetIniValue("System", Class, "UseSpatial", UseSpatial.ToString());
-	engine->packages->SetIniValue("System", Class, "UseReverb", UseReverb.ToString());
-	engine->packages->SetIniValue("System", Class, "Use3dHardware", Use3dHardware.ToString());
-	engine->packages->SetIniValue("System", Class, "LowSoundQuality", LowSoundQuality.ToString());
-	engine->packages->SetIniValue("System", Class, "ReverseStereo", ReverseStereo.ToString());
-	engine->packages->SetIniValue("System", Class, "Latency", Latency.ToString());
-	engine->packages->SetIniValue("System", Class, "OutputRate", OutputRate.ToString());
-	engine->packages->SetIniValue("System", Class, "Channels", Channels.ToString());
-	engine->packages->SetIniValue("System", Class, "MusicVolume", MusicVolume.ToString());
-	engine->packages->SetIniValue("System", Class, "SoundVolume", SoundVolume.ToString());
-	engine->packages->SetIniValue("System", Class, "AmbientFactor", AmbientFactor.ToString());
+	engine->packages->SetIniValue("System", Class, "UseFilter", IniPropertyConverter<bool>::ToString(UseFilter));
+	engine->packages->SetIniValue("System", Class, "UseSurround", IniPropertyConverter<bool>::ToString(UseSurround));
+	engine->packages->SetIniValue("System", Class, "UseStereo", IniPropertyConverter<bool>::ToString(UseStereo));
+	engine->packages->SetIniValue("System", Class, "UseCDMusic", IniPropertyConverter<bool>::ToString(UseCDMusic));
+	engine->packages->SetIniValue("System", Class, "UseDigitalMusic", IniPropertyConverter<bool>::ToString(UseDigitalMusic));
+	engine->packages->SetIniValue("System", Class, "UseSpatial", IniPropertyConverter<bool>::ToString(UseSpatial));
+	engine->packages->SetIniValue("System", Class, "UseReverb", IniPropertyConverter<bool>::ToString(UseReverb));
+	engine->packages->SetIniValue("System", Class, "Use3dHardware", IniPropertyConverter<bool>::ToString(Use3dHardware));
+	engine->packages->SetIniValue("System", Class, "LowSoundQuality", IniPropertyConverter<bool>::ToString(LowSoundQuality));
+	engine->packages->SetIniValue("System", Class, "ReverseStereo", IniPropertyConverter<bool>::ToString(ReverseStereo));
+	engine->packages->SetIniValue("System", Class, "Latency", IniPropertyConverter<int>::ToString(Latency));
+	engine->packages->SetIniValue("System", Class, "OutputRate", IniPropertyConverter<int>::ToString(OutputRate));
+	engine->packages->SetIniValue("System", Class, "Channels", IniPropertyConverter<int>::ToString(Channels));
+	engine->packages->SetIniValue("System", Class, "MusicVolume", IniPropertyConverter<uint8_t>::ToString(MusicVolume));
+	engine->packages->SetIniValue("System", Class, "SoundVolume", IniPropertyConverter<uint8_t>::ToString(SoundVolume));
+	engine->packages->SetIniValue("System", Class, "AmbientFactor", IniPropertyConverter<float>::ToString(AmbientFactor));
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -218,40 +218,40 @@ void USurrealClient::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	StartupFullscreen.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "StartupFullscreen");
-	WindowedViewportX.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportX");
-	WindowedViewportY.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportY");
-	WindowedColorBits.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedColorBits");
-	FullscreenViewportX.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportX");
-	FullscreenViewportY.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportY");
-	FullscreenColorBits.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenColorBits");
-	Brightness.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Brightness");
-	UseJoystick.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseJoystick");
-	UseDirectInput.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDirectInput");
-	MinDesiredFrameRate.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MinDesiredFrameRate");
-	Decals.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Decals");
-	NoDynamicLights.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "NoDynamicLights");
-	TextureDetail.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "TextureDetail");
-	SkinDetail.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SkinDetail");
+	StartupFullscreen = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "StartupFullscreen");
+	WindowedViewportX = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportX");
+	WindowedViewportY = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportY");
+	WindowedColorBits = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedColorBits");
+	FullscreenViewportX = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportX");
+	FullscreenViewportY = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportY");
+	FullscreenColorBits = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenColorBits");
+	Brightness = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Brightness");
+	UseJoystick = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseJoystick");
+	UseDirectInput = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDirectInput");
+	MinDesiredFrameRate = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MinDesiredFrameRate");
+	Decals = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Decals");
+	NoDynamicLights = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "NoDynamicLights");
+	TextureDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "TextureDetail");
+	SkinDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SkinDetail");
 }
 
 void USurrealClient::SaveProperties()
 {
-	engine->packages->SetIniValue("System", Class, "StartupFullscreen", StartupFullscreen.ToString());
-	engine->packages->SetIniValue("System", Class, "WindowedViewportX", WindowedViewportX.ToString());
-	engine->packages->SetIniValue("System", Class, "WindowedViewportY", WindowedViewportY.ToString());
-	engine->packages->SetIniValue("System", Class, "WindowedColorBits", WindowedColorBits.ToString());
-	engine->packages->SetIniValue("System", Class, "FullscreenViewportX", FullscreenViewportX.ToString());
-	engine->packages->SetIniValue("System", Class, "FullscreenViewportY", FullscreenViewportY.ToString());
-	engine->packages->SetIniValue("System", Class, "FullscreenColorBits", FullscreenColorBits.ToString());
-	engine->packages->SetIniValue("System", Class, "Brightness", Brightness.ToString());
-	engine->packages->SetIniValue("System", Class, "UseJoystick", UseJoystick.ToString());
-	engine->packages->SetIniValue("System", Class, "UseDirectInput", UseDirectInput.ToString());
-	engine->packages->SetIniValue("System", Class, "MinDesiredFrameRate", MinDesiredFrameRate.ToString());
-	engine->packages->SetIniValue("System", Class, "Decals", Decals.ToString());
-	engine->packages->SetIniValue("System", Class, "NoDynamicLights", NoDynamicLights.ToString());
-	engine->packages->SetIniValue("System", Class, "TextureDetail", TextureDetail.Value());
-	engine->packages->SetIniValue("System", Class, "SkinDetail", SkinDetail.Value());
+	engine->packages->SetIniValue("System", Class, "StartupFullscreen", IniPropertyConverter<bool>::ToString(StartupFullscreen));
+	engine->packages->SetIniValue("System", Class, "WindowedViewportX", IniPropertyConverter<int>::ToString(WindowedViewportX));
+	engine->packages->SetIniValue("System", Class, "WindowedViewportY", IniPropertyConverter<int>::ToString(WindowedViewportY));
+	engine->packages->SetIniValue("System", Class, "WindowedColorBits", IniPropertyConverter<int>::ToString(WindowedColorBits));
+	engine->packages->SetIniValue("System", Class, "FullscreenViewportX", IniPropertyConverter<int>::ToString(FullscreenViewportX));
+	engine->packages->SetIniValue("System", Class, "FullscreenViewportY", IniPropertyConverter<int>::ToString(FullscreenViewportY));
+	engine->packages->SetIniValue("System", Class, "FullscreenColorBits", IniPropertyConverter<int>::ToString(FullscreenColorBits));
+	engine->packages->SetIniValue("System", Class, "Brightness", IniPropertyConverter<float>::ToString(Brightness));
+	engine->packages->SetIniValue("System", Class, "UseJoystick", IniPropertyConverter<bool>::ToString(UseJoystick));
+	engine->packages->SetIniValue("System", Class, "UseDirectInput", IniPropertyConverter<bool>::ToString(UseDirectInput));
+	engine->packages->SetIniValue("System", Class, "MinDesiredFrameRate", IniPropertyConverter<int>::ToString(MinDesiredFrameRate));
+	engine->packages->SetIniValue("System", Class, "Decals", IniPropertyConverter<bool>::ToString(Decals));
+	engine->packages->SetIniValue("System", Class, "NoDynamicLights", IniPropertyConverter<bool>::ToString(NoDynamicLights));
+	engine->packages->SetIniValue("System", Class, "TextureDetail", TextureDetail);
+	engine->packages->SetIniValue("System", Class, "SkinDetail", SkinDetail);
 }
 
 std::string USurrealClient::GetPropertyAsString(const NameString& propertyName) const
@@ -259,35 +259,35 @@ std::string USurrealClient::GetPropertyAsString(const NameString& propertyName) 
 	if (propertyName == "Class")
 		return "class'" + Class + "'";
 	else if (propertyName == "StartupFullscreen")
-		return StartupFullscreen.ToString();
+		return IniPropertyConverter<bool>::ToString(StartupFullscreen);
 	else if (propertyName == "WindowedViewportX")
-		return WindowedViewportX.ToString();
+		return IniPropertyConverter<int>::ToString(WindowedViewportX);
 	else if (propertyName == "WindowedViewportY")
-		return WindowedViewportY.ToString();
+		return IniPropertyConverter<int>::ToString(WindowedViewportY);
 	else if (propertyName == "WindowedColorBits")
-		return WindowedColorBits.ToString();
+		return IniPropertyConverter<int>::ToString(WindowedColorBits);
 	else if (propertyName == "FullscreenViewportX")
-		return FullscreenViewportX.ToString();
+		return IniPropertyConverter<int>::ToString(FullscreenViewportX);
 	else if (propertyName == "FullscreenViewportY")
-		return FullscreenViewportY.ToString();
+		return IniPropertyConverter<int>::ToString(FullscreenViewportY);
 	else if (propertyName == "FullscreenColorBits")
-		return FullscreenColorBits.ToString();
+		return IniPropertyConverter<int>::ToString(FullscreenColorBits);
 	else if (propertyName == "Brightness")
-		return Brightness.ToString();
+		return IniPropertyConverter<float>::ToString(Brightness);
 	else if (propertyName == "UseJoystick")
-		return UseJoystick.ToString();
+		return IniPropertyConverter<bool>::ToString(UseJoystick);
 	else if (propertyName == "UseDirectInput")
-		return UseDirectInput.ToString();
+		return IniPropertyConverter<bool>::ToString(UseDirectInput);
 	else if (propertyName == "MinDesiredFrameRate")
-		return MinDesiredFrameRate.ToString();
+		return IniPropertyConverter<int>::ToString(MinDesiredFrameRate);
 	else if (propertyName == "Decals")
-		return Decals.ToString();
+		return IniPropertyConverter<bool>::ToString(Decals);
 	else if (propertyName == "NoDynamicLights")
-		return NoDynamicLights.ToString();
+		return IniPropertyConverter<bool>::ToString(NoDynamicLights);
 	else if (propertyName == "TextureDetail")
-		return TextureDetail.Value();
+		return TextureDetail;
 	else if (propertyName == "SkinDetail")
-		return SkinDetail.Value();
+		return SkinDetail;
 
 	engine->LogMessage("Queried unknown property for Surreal.ViewportManager: " + propertyName.ToString());
 	return {};
@@ -296,29 +296,29 @@ std::string USurrealClient::GetPropertyAsString(const NameString& propertyName) 
 void USurrealClient::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	if (propertyName == "WindowedViewportX")
-		WindowedViewportX.FromString(value);
+		WindowedViewportX = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "WindowedViewportY")
-		WindowedViewportY.FromString(value);
+		WindowedViewportY = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "WindowedColorBits")
-		WindowedColorBits.FromString(value);
+		WindowedColorBits = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "FullscreenViewportX")
-		FullscreenViewportX.FromString(value);
+		FullscreenViewportX = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "FullscreenViewportY")
-		FullscreenViewportY.FromString(value);
+		FullscreenViewportY = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "FullscreenColorBits")
-		FullscreenColorBits.FromString(value);
+		FullscreenColorBits = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "Brightness")
-		Brightness.FromString(value);
+		Brightness = IniPropertyConverter<float>::FromString(value);
 	else if (propertyName == "UseJoystick")
-		UseJoystick.FromString(value);
+		UseJoystick = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "UseDirectInput")
-		UseDirectInput.FromString(value);
+		UseDirectInput = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "MinDesiredFrameRate")
-		MinDesiredFrameRate.FromString(value);
+		MinDesiredFrameRate = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "Decals")
-		Decals.FromString(value);
+		Decals = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "NoDynamicLights")
-		NoDynamicLights.FromString(value);
+		NoDynamicLights = IniPropertyConverter<bool>::FromString(value);
 	else if (propertyName == "TextureDetail")
 		TextureDetail = value;
 	else if (propertyName == "SkinDetail")

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -49,7 +49,6 @@ void USurrealRenderDevice::LoadProperties(const NameString& from)
 		name_from = NameString(Class);
 
 	Translucency.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Translucency");
-	//Translucency = std::atoi(engine->packages->GetIniValue("System", name_from, "Translucency", Translucency.ToString()).c_str());
 	VolumetricLighting.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "VolumetricLighting");
 	ShinySurfaces.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ShinySurfaces");
 	Coronas.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Coronas");
@@ -171,24 +170,6 @@ void USurrealAudioDevice::LoadProperties(const NameString& from)
 	MusicVolume.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MusicVolume");
 	SoundVolume.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SoundVolume");
 	AmbientFactor.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor");
-	/*
-	UseFilter = std::atoi(engine->packages->GetIniValue("System", name_from, "UseFilter", UseFilter.ToString()).c_str());
-	UseSurround = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSurround", UseSurround.ToString()).c_str());
-	UseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "UseStereo", UseStereo.ToString()).c_str());
-	UseCDMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseCDMusic", UseCDMusic.ToString()).c_str());
-	UseDigitalMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseDigitalMusic", UseDigitalMusic.ToString()).c_str());
-	UseSpatial = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSpatial", UseSpatial.ToString()).c_str());
-	UseReverb = std::atoi(engine->packages->GetIniValue("System", name_from, "UseReverb", UseReverb.ToString()).c_str());
-	Use3dHardware = std::atoi(engine->packages->GetIniValue("System", name_from, "Use3dHardware", Use3dHardware.ToString()).c_str());
-	LowSoundQuality = std::atoi(engine->packages->GetIniValue("System", name_from, "LowSoundQuality", LowSoundQuality.ToString()).c_str());
-	ReverseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "ReverseStereo", ReverseStereo.ToString()).c_str());
-	Latency = std::atoi(engine->packages->GetIniValue("System", name_from, "Latency", Latency.ToString()).c_str());
-	OutputRate = std::atoi(engine->packages->GetIniValue("System", name_from, "OutputRate", OutputRate.ToString()).c_str());
-	Channels = std::atoi(engine->packages->GetIniValue("System", name_from, "Channels", Channels.ToString()).c_str());
-	MusicVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "MusicVolume", MusicVolume.ToString()).c_str());
-	SoundVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "SoundVolume", SoundVolume.ToString()).c_str());
-	AmbientFactor = (float)std::atof(engine->packages->GetIniValue("System", name_from, "AmbientFactor", AmbientFactor.ToString()).c_str());
-	*/
 }
 
 void USurrealAudioDevice::SaveProperties()

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -216,35 +216,35 @@ std::string USurrealClient::GetPropertyAsString(const NameString& propertyName) 
 	if (propertyName == "Class")
 		return "class'" + Class + "'";
 	else if (propertyName == "StartupFullscreen")
-		return StartupFullscreen ? "1" : "0";
+		return StartupFullscreen.ToString();
 	else if (propertyName == "WindowedViewportX")
-		return std::to_string(WindowedViewportX);
+		return WindowedViewportX.ToString();
 	else if (propertyName == "WindowedViewportY")
-		return std::to_string(WindowedViewportY);
+		return WindowedViewportY.ToString();
 	else if (propertyName == "WindowedColorBits")
-		return std::to_string(WindowedColorBits);
+		return WindowedColorBits.ToString();
 	else if (propertyName == "FullscreenViewportX")
-		return std::to_string(FullscreenViewportX);
+		return FullscreenViewportX.ToString();
 	else if (propertyName == "FullscreenViewportY")
-		return std::to_string(FullscreenViewportY);
+		return FullscreenViewportY.ToString();
 	else if (propertyName == "FullscreenColorBits")
-		return std::to_string(FullscreenColorBits);
+		return FullscreenColorBits.ToString();
 	else if (propertyName == "Brightness")
-		return std::to_string(Brightness);
+		return Brightness.ToString();
 	else if (propertyName == "UseJoystick")
-		return UseJoystick ? "1" : "0";
+		return UseJoystick.ToString();
 	else if (propertyName == "UseDirectInput")
-		return UseDirectInput ? "1" : "0";
+		return UseDirectInput.ToString();
 	else if (propertyName == "MinDesiredFrameRate")
-		return std::to_string(MinDesiredFrameRate);
+		return MinDesiredFrameRate.ToString();
 	else if (propertyName == "Decals")
-		return Decals ? "1" : "0";
+		return Decals.ToString();
 	else if (propertyName == "NoDynamicLights")
-		return NoDynamicLights ? "1" : "0";
+		return NoDynamicLights.ToString();
 	else if (propertyName == "TextureDetail")
-		return TextureDetail;
+		return TextureDetail.Value();
 	else if (propertyName == "SkinDetail")
-		return SkinDetail;
+		return SkinDetail.Value();
 
 	engine->LogMessage("Queried unknown property for Surreal.ViewportManager: " + propertyName.ToString());
 	return {};
@@ -253,29 +253,29 @@ std::string USurrealClient::GetPropertyAsString(const NameString& propertyName) 
 void USurrealClient::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	if (propertyName == "WindowedViewportX")
-		WindowedViewportX = std::atoi(value.c_str());
+		WindowedViewportX.FromString(value);
 	else if (propertyName == "WindowedViewportY")
-		WindowedViewportY = std::atoi(value.c_str());
+		WindowedViewportY.FromString(value);
 	else if (propertyName == "WindowedColorBits")
-		WindowedColorBits = std::atoi(value.c_str());
+		WindowedColorBits.FromString(value);
 	else if (propertyName == "FullscreenViewportX")
-		FullscreenViewportX = std::atoi(value.c_str());
+		FullscreenViewportX.FromString(value);
 	else if (propertyName == "FullscreenViewportY")
-		FullscreenViewportY = std::atoi(value.c_str());
+		FullscreenViewportY.FromString(value);
 	else if (propertyName == "FullscreenColorBits")
-		FullscreenColorBits = std::atoi(value.c_str());
+		FullscreenColorBits.FromString(value);
 	else if (propertyName == "Brightness")
-		Brightness = (float)std::atof(value.c_str());
+		Brightness.FromString(value);
 	else if (propertyName == "UseJoystick")
-		UseJoystick = std::atoi(value.c_str());
+		UseJoystick.FromString(value);
 	else if (propertyName == "UseDirectInput")
-		UseDirectInput = std::atoi(value.c_str());
+		UseDirectInput.FromString(value);
 	else if (propertyName == "MinDesiredFrameRate")
-		MinDesiredFrameRate = std::atoi(value.c_str());
+		MinDesiredFrameRate.FromString(value);
 	else if (propertyName == "Decals")
-		Decals = std::atoi(value.c_str());
+		Decals.FromString(value);
 	else if (propertyName == "NoDynamicLights")
-		NoDynamicLights = std::atoi(value.c_str());
+		NoDynamicLights.FromString(value);
 	else if (propertyName == "TextureDetail")
 		TextureDetail = value;
 	else if (propertyName == "SkinDetail")

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -41,6 +41,29 @@ void USurrealRenderDevice::SetPropertyFromString(const NameString& propertyName,
 	engine->packages->SetIniValue("System", Class, propertyName, value);
 }
 
+void USurrealRenderDevice::LoadProperties(const NameString& from)
+{	
+	NameString name_from = from;
+	
+	if (from == "")
+		name_from = NameString(Class);
+
+	Translucency = std::atoi(engine->packages->GetIniValue("System", name_from, "Translucency", std::to_string(Translucency)).c_str());
+	VolumetricLighting = std::atoi(engine->packages->GetIniValue("System", name_from, "VolumetricLighting", std::to_string(VolumetricLighting)).c_str());
+	ShinySurfaces = std::atoi(engine->packages->GetIniValue("System", name_from, "ShinySurfaces", std::to_string(ShinySurfaces)).c_str());
+	Coronas = std::atoi(engine->packages->GetIniValue("System", name_from, "Coronas", std::to_string(Coronas)).c_str());
+	HighDetailActors = std::atoi(engine->packages->GetIniValue("System", name_from, "HighDetailActors", std::to_string(HighDetailActors)).c_str());
+}
+
+void USurrealRenderDevice::SaveProperties()
+{
+	engine->packages->SetIniValue("System", Class, "Translucency", std::to_string(Translucency));
+	engine->packages->SetIniValue("System", Class, "VolumetricLighting", std::to_string(VolumetricLighting));
+	engine->packages->SetIniValue("System", Class, "ShinySurfaces", std::to_string(ShinySurfaces));
+	engine->packages->SetIniValue("System", Class, "Coronas", std::to_string(Coronas));
+	engine->packages->SetIniValue("System", Class, "HighDetailActors", std::to_string(HighDetailActors));
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 std::string USurrealAudioDevice::GetPropertyAsString(const NameString& propertyName) const
@@ -122,6 +145,51 @@ void USurrealAudioDevice::SetPropertyFromString(const NameString& propertyName, 
 		engine->LogMessage("Setting unknown property for SurrealAudioDevice: " + propertyName.ToString());
 
 	engine->packages->SetIniValue("System", Class, propertyName, value);
+}
+
+void USurrealAudioDevice::LoadProperties(const NameString& from)
+{
+	NameString name_from = from;
+
+	if (from == "")
+		name_from = NameString(Class);
+
+	UseFilter = std::atoi(engine->packages->GetIniValue("System", name_from, "UseFilter", std::to_string(UseFilter)).c_str());
+	UseSurround = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSurround", std::to_string(UseSurround)).c_str());
+	UseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "UseStereo", std::to_string(UseStereo)).c_str());
+	UseCDMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseCDMusic", std::to_string(UseCDMusic)).c_str());
+	UseDigitalMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseDigitalMusic", std::to_string(UseDigitalMusic)).c_str());
+	UseSpatial = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSpatial", std::to_string(UseSpatial)).c_str());
+	UseReverb = std::atoi(engine->packages->GetIniValue("System", name_from, "UseReverb", std::to_string(UseReverb)).c_str());
+	Use3dHardware = std::atoi(engine->packages->GetIniValue("System", name_from, "Use3dHardware", std::to_string(Use3dHardware)).c_str());
+	LowSoundQuality = std::atoi(engine->packages->GetIniValue("System", name_from, "LowSoundQuality", std::to_string(LowSoundQuality)).c_str());
+	ReverseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "ReverseStereo", std::to_string(ReverseStereo)).c_str());
+	Latency = std::atoi(engine->packages->GetIniValue("System", name_from, "Latency", std::to_string(Latency)).c_str());
+	OutputRate = std::atoi(engine->packages->GetIniValue("System", name_from, "OutputRate", std::to_string(OutputRate)).c_str());
+	Channels = std::atoi(engine->packages->GetIniValue("System", name_from, "Channels", std::to_string(Channels)).c_str());
+	MusicVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "MusicVolume", std::to_string(MusicVolume)).c_str());
+	SoundVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "SoundVolume", std::to_string(SoundVolume)).c_str());
+	AmbientFactor = (float)std::atof(engine->packages->GetIniValue("System", name_from, "AmbientFactor", std::to_string(AmbientFactor)).c_str());
+}
+
+void USurrealAudioDevice::SaveProperties()
+{
+	engine->packages->SetIniValue("System", Class, "UseFilter", std::to_string(UseFilter));
+	engine->packages->SetIniValue("System", Class, "UseSurround", std::to_string(UseSurround));
+	engine->packages->SetIniValue("System", Class, "UseStereo", std::to_string(UseStereo));
+	engine->packages->SetIniValue("System", Class, "UseCDMusic", std::to_string(UseCDMusic));
+	engine->packages->SetIniValue("System", Class, "UseDigitalMusic", std::to_string(UseDigitalMusic));
+	engine->packages->SetIniValue("System", Class, "UseSpatial", std::to_string(UseSpatial));
+	engine->packages->SetIniValue("System", Class, "UseReverb", std::to_string(UseReverb));
+	engine->packages->SetIniValue("System", Class, "Use3dHardware", std::to_string(Use3dHardware));
+	engine->packages->SetIniValue("System", Class, "LowSoundQuality", std::to_string(LowSoundQuality));
+	engine->packages->SetIniValue("System", Class, "ReverseStereo", std::to_string(ReverseStereo));
+	engine->packages->SetIniValue("System", Class, "Latency", std::to_string(Latency));
+	engine->packages->SetIniValue("System", Class, "OutputRate", std::to_string(OutputRate));
+	engine->packages->SetIniValue("System", Class, "Channels", std::to_string(Channels));
+	engine->packages->SetIniValue("System", Class, "MusicVolume", std::to_string(MusicVolume));
+	engine->packages->SetIniValue("System", Class, "SoundVolume", std::to_string(SoundVolume));
+	engine->packages->SetIniValue("System", Class, "AmbientFactor", std::to_string(AmbientFactor));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -2,6 +2,7 @@
 #include "Precomp.h"
 #include "USubsystem.h"
 #include "Engine.h"
+#include "Package/PackageManager.h"
 
 std::string USurrealRenderDevice::GetPropertyAsString(const NameString& propertyName) const
 {
@@ -36,6 +37,8 @@ void USurrealRenderDevice::SetPropertyFromString(const NameString& propertyName,
 		HighDetailActors = std::atoi(value.c_str());
 	else
 		engine->LogMessage("Setting unknown property for SurrealRenderDevice: " + propertyName.ToString());
+
+	engine->packages->SetIniValue("System", Class, propertyName, value);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -117,6 +120,8 @@ void USurrealAudioDevice::SetPropertyFromString(const NameString& propertyName, 
 		AmbientFactor = (float)std::atof(value.c_str());
 	else
 		engine->LogMessage("Setting unknown property for SurrealAudioDevice: " + propertyName.ToString());
+
+	engine->packages->SetIniValue("System", Class, propertyName, value);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -133,6 +138,7 @@ std::string USurrealNetworkDevice::GetPropertyAsString(const NameString& propert
 void USurrealNetworkDevice::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	engine->LogMessage("Setting unknown property for SurrealNetworkDevice: " + propertyName.ToString());
+	engine->packages->SetIniValue("System", Class, propertyName, value);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -208,4 +214,6 @@ void USurrealClient::SetPropertyFromString(const NameString& propertyName, const
 		SkinDetail = value;
 	else
 		engine->LogMessage("Setting unknown property for Surreal.ViewportManager: " + propertyName.ToString());
+
+	engine->packages->SetIniValue("System", Class, propertyName, value);
 }

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -211,6 +211,49 @@ void USurrealNetworkDevice::SetPropertyFromString(const NameString& propertyName
 
 /////////////////////////////////////////////////////////////////////////////
 
+void USurrealClient::LoadProperties(const NameString& from)
+{
+	NameString name_from = from;
+
+	if (from == "")
+		name_from = NameString(Class);
+
+	StartupFullscreen.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "StartupFullscreen");
+	WindowedViewportX.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportX");
+	WindowedViewportY.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportY");
+	WindowedColorBits.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedColorBits");
+	FullscreenViewportX.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportX");
+	FullscreenViewportY.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportY");
+	FullscreenColorBits.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenColorBits");
+	Brightness.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Brightness");
+	UseJoystick.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseJoystick");
+	UseDirectInput.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDirectInput");
+	MinDesiredFrameRate.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MinDesiredFrameRate");
+	Decals.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Decals");
+	NoDynamicLights.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "NoDynamicLights");
+	TextureDetail.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "TextureDetail");
+	SkinDetail.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SkinDetail");
+}
+
+void USurrealClient::SaveProperties()
+{
+	engine->packages->SetIniValue("System", Class, "StartupFullscreen", StartupFullscreen.ToString());
+	engine->packages->SetIniValue("System", Class, "WindowedViewportX", WindowedViewportX.ToString());
+	engine->packages->SetIniValue("System", Class, "WindowedViewportY", WindowedViewportY.ToString());
+	engine->packages->SetIniValue("System", Class, "WindowedColorBits", WindowedColorBits.ToString());
+	engine->packages->SetIniValue("System", Class, "FullscreenViewportX", FullscreenViewportX.ToString());
+	engine->packages->SetIniValue("System", Class, "FullscreenViewportY", FullscreenViewportY.ToString());
+	engine->packages->SetIniValue("System", Class, "FullscreenColorBits", FullscreenColorBits.ToString());
+	engine->packages->SetIniValue("System", Class, "Brightness", Brightness.ToString());
+	engine->packages->SetIniValue("System", Class, "UseJoystick", UseJoystick.ToString());
+	engine->packages->SetIniValue("System", Class, "UseDirectInput", UseDirectInput.ToString());
+	engine->packages->SetIniValue("System", Class, "MinDesiredFrameRate", MinDesiredFrameRate.ToString());
+	engine->packages->SetIniValue("System", Class, "Decals", Decals.ToString());
+	engine->packages->SetIniValue("System", Class, "NoDynamicLights", NoDynamicLights.ToString());
+	engine->packages->SetIniValue("System", Class, "TextureDetail", TextureDetail.Value());
+	engine->packages->SetIniValue("System", Class, "SkinDetail", SkinDetail.Value());
+}
+
 std::string USurrealClient::GetPropertyAsString(const NameString& propertyName) const
 {
 	if (propertyName == "Class")

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -9,15 +9,15 @@ std::string USurrealRenderDevice::GetPropertyAsString(const NameString& property
 	if (propertyName == "Class")
 		return "class'" + Class + "'";
 	if (propertyName == "Translucency")
-		return Translucency ? "1" : "0";
+		return Translucency.ToString();
 	else if (propertyName == "VolumetricLighting")
-		return VolumetricLighting ? "1" : "0";
+		return VolumetricLighting.ToString();
 	else if (propertyName == "ShinySurfaces")
-		return ShinySurfaces ? "1" : "0";
+		return ShinySurfaces.ToString();
 	else if (propertyName == "Coronas")
-		return Coronas ? "1" : "0";
+		return Coronas.ToString();
 	else if (propertyName == "HighDetailActors")
-		return HighDetailActors ? "1" : "0";
+		return HighDetailActors.ToString();
 
 	engine->LogMessage("Queried unknown property for SurrealRenderDevice: " + propertyName.ToString());
 	return {};
@@ -26,15 +26,15 @@ std::string USurrealRenderDevice::GetPropertyAsString(const NameString& property
 void USurrealRenderDevice::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	if (propertyName == "Translucency")
-		Translucency = std::atoi(value.c_str());
+		Translucency.FromString(value);
 	else if (propertyName == "VolumetricLighting")
-		VolumetricLighting = std::atoi(value.c_str());
+		VolumetricLighting.FromString(value);
 	else if (propertyName == "ShinySurfaces")
-		ShinySurfaces = std::atoi(value.c_str());
+		ShinySurfaces.FromString(value);
 	else if (propertyName == "Coronas")
-		Coronas = std::atoi(value.c_str());
+		Coronas.FromString(value);
 	else if (propertyName == "HighDetailActors")
-		HighDetailActors = std::atoi(value.c_str());
+		HighDetailActors.FromString(value);
 	else
 		engine->LogMessage("Setting unknown property for SurrealRenderDevice: " + propertyName.ToString());
 
@@ -48,20 +48,21 @@ void USurrealRenderDevice::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	Translucency = std::atoi(engine->packages->GetIniValue("System", name_from, "Translucency", std::to_string(Translucency)).c_str());
-	VolumetricLighting = std::atoi(engine->packages->GetIniValue("System", name_from, "VolumetricLighting", std::to_string(VolumetricLighting)).c_str());
-	ShinySurfaces = std::atoi(engine->packages->GetIniValue("System", name_from, "ShinySurfaces", std::to_string(ShinySurfaces)).c_str());
-	Coronas = std::atoi(engine->packages->GetIniValue("System", name_from, "Coronas", std::to_string(Coronas)).c_str());
-	HighDetailActors = std::atoi(engine->packages->GetIniValue("System", name_from, "HighDetailActors", std::to_string(HighDetailActors)).c_str());
+	Translucency.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Translucency");
+	//Translucency = std::atoi(engine->packages->GetIniValue("System", name_from, "Translucency", Translucency.ToString()).c_str());
+	VolumetricLighting.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "VolumetricLighting");
+	ShinySurfaces.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ShinySurfaces");
+	Coronas.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Coronas");
+	HighDetailActors.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "HighDetailActors");
 }
 
 void USurrealRenderDevice::SaveProperties()
 {
-	engine->packages->SetIniValue("System", Class, "Translucency", std::to_string(Translucency));
-	engine->packages->SetIniValue("System", Class, "VolumetricLighting", std::to_string(VolumetricLighting));
-	engine->packages->SetIniValue("System", Class, "ShinySurfaces", std::to_string(ShinySurfaces));
-	engine->packages->SetIniValue("System", Class, "Coronas", std::to_string(Coronas));
-	engine->packages->SetIniValue("System", Class, "HighDetailActors", std::to_string(HighDetailActors));
+	engine->packages->SetIniValue("System", Class, "Translucency", Translucency.ToString());
+	engine->packages->SetIniValue("System", Class, "VolumetricLighting", VolumetricLighting.ToString());
+	engine->packages->SetIniValue("System", Class, "ShinySurfaces", ShinySurfaces.ToString());
+	engine->packages->SetIniValue("System", Class, "Coronas", Coronas.ToString());
+	engine->packages->SetIniValue("System", Class, "HighDetailActors", HighDetailActors.ToString());
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -71,37 +72,37 @@ std::string USurrealAudioDevice::GetPropertyAsString(const NameString& propertyN
 	if (propertyName == "Class")
 		return "class'" + Class + "'";
 	else if (propertyName == "UseFilter")
-		return UseFilter ? "1" : "0";
+		return UseFilter.ToString();
 	else if (propertyName == "UseSurround")
-		return UseSurround ? "1" : "0";
+		return UseSurround.ToString();
 	else if (propertyName == "UseStereo")
-		return UseStereo ? "1" : "0";
+		return UseStereo.ToString();
 	else if (propertyName == "UseCDMusic")
-		return UseCDMusic ? "1" : "0";
+		return UseCDMusic.ToString();
 	else if (propertyName == "UseDigitalMusic")
-		return UseDigitalMusic ? "1" : "0";
+		return UseDigitalMusic.ToString();
 	else if (propertyName == "UseSpatial")
-		return UseSpatial ? "1" : "0";
+		return UseSpatial.ToString();
 	else if (propertyName == "UseReverb")
-		return UseReverb ? "1" : "0";
+		return UseReverb.ToString();
 	else if (propertyName == "Use3dHardware")
-		return Use3dHardware ? "1" : "0";
+		return Use3dHardware.ToString();
 	else if (propertyName == "LowSoundQuality")
-		return LowSoundQuality ? "1" : "0";
+		return LowSoundQuality.ToString();
 	else if (propertyName == "ReverseStereo")
-		return ReverseStereo ? "1" : "0";
+		return ReverseStereo.ToString();
 	else if (propertyName == "Latency")
-		return std::to_string(Latency);
+		return Latency.ToString();
 	else if (propertyName == "OutputRate")
-		return std::to_string(OutputRate);
+		return OutputRate.ToString();
 	else if (propertyName == "Channels")
-		return std::to_string(Channels);
+		return Channels.ToString();
 	else if (propertyName == "MusicVolume")
-		return std::to_string(MusicVolume);
+		return MusicVolume.ToString();
 	else if (propertyName == "SoundVolume")
-		return std::to_string(SoundVolume);
+		return SoundVolume.ToString();
 	else if (propertyName == "AmbientFactor")
-		return std::to_string(AmbientFactor);
+		return AmbientFactor.ToString();
 
 	engine->LogMessage("Queried unknown property for SurrealAudioDevice: " + propertyName.ToString());
 	return {};
@@ -110,37 +111,37 @@ std::string USurrealAudioDevice::GetPropertyAsString(const NameString& propertyN
 void USurrealAudioDevice::SetPropertyFromString(const NameString& propertyName, const std::string& value)
 {
 	if (propertyName == "UseFilter")
-		UseFilter = std::atoi(value.c_str());
+		UseFilter.FromString(value);
 	else if (propertyName == "UseSurround")
-		UseSurround = std::atoi(value.c_str());
+		UseSurround.FromString(value);
 	else if (propertyName == "UseStereo")
-		UseStereo = std::atoi(value.c_str());
+		UseStereo.FromString(value);
 	else if (propertyName == "UseCDMusic")
-		UseCDMusic = std::atoi(value.c_str());
+		UseCDMusic.FromString(value);
 	else if (propertyName == "UseDigitalMusic")
-		UseDigitalMusic = std::atoi(value.c_str());
+		UseDigitalMusic.FromString(value);
 	else if (propertyName == "UseSpatial")
-		UseSpatial = std::atoi(value.c_str());
+		UseSpatial.FromString(value);
 	else if (propertyName == "UseReverb")
-		UseReverb = std::atoi(value.c_str());
+		UseReverb.FromString(value);
 	else if (propertyName == "Use3dHardware")
-		Use3dHardware = std::atoi(value.c_str());
+		Use3dHardware.FromString(value);
 	else if (propertyName == "LowSoundQuality")
-		LowSoundQuality = std::atoi(value.c_str());
+		LowSoundQuality.FromString(value);
 	else if (propertyName == "ReverseStereo")
-		ReverseStereo = std::atoi(value.c_str());
+		ReverseStereo.FromString(value);
 	else if (propertyName == "Latency")
-		Latency = std::atoi(value.c_str());
+		Latency.FromString(value);
 	else if (propertyName == "OutputRate")
-		OutputRate = std::atoi(value.c_str());
+		OutputRate.FromString(value);
 	else if (propertyName == "Channels")
-		Channels = std::atoi(value.c_str());
+		Channels.FromString(value);
 	else if (propertyName == "MusicVolume")
-		MusicVolume = std::atoi(value.c_str());
+		MusicVolume.FromString(value);
 	else if (propertyName == "SoundVolume")
-		SoundVolume = std::atoi(value.c_str());
+		SoundVolume.FromString(value);
 	else if (propertyName == "AmbientFactor")
-		AmbientFactor = (float)std::atof(value.c_str());
+		AmbientFactor.FromString(value);
 	else
 		engine->LogMessage("Setting unknown property for SurrealAudioDevice: " + propertyName.ToString());
 
@@ -154,42 +155,60 @@ void USurrealAudioDevice::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	UseFilter = std::atoi(engine->packages->GetIniValue("System", name_from, "UseFilter", std::to_string(UseFilter)).c_str());
-	UseSurround = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSurround", std::to_string(UseSurround)).c_str());
-	UseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "UseStereo", std::to_string(UseStereo)).c_str());
-	UseCDMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseCDMusic", std::to_string(UseCDMusic)).c_str());
-	UseDigitalMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseDigitalMusic", std::to_string(UseDigitalMusic)).c_str());
-	UseSpatial = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSpatial", std::to_string(UseSpatial)).c_str());
-	UseReverb = std::atoi(engine->packages->GetIniValue("System", name_from, "UseReverb", std::to_string(UseReverb)).c_str());
-	Use3dHardware = std::atoi(engine->packages->GetIniValue("System", name_from, "Use3dHardware", std::to_string(Use3dHardware)).c_str());
-	LowSoundQuality = std::atoi(engine->packages->GetIniValue("System", name_from, "LowSoundQuality", std::to_string(LowSoundQuality)).c_str());
-	ReverseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "ReverseStereo", std::to_string(ReverseStereo)).c_str());
-	Latency = std::atoi(engine->packages->GetIniValue("System", name_from, "Latency", std::to_string(Latency)).c_str());
-	OutputRate = std::atoi(engine->packages->GetIniValue("System", name_from, "OutputRate", std::to_string(OutputRate)).c_str());
-	Channels = std::atoi(engine->packages->GetIniValue("System", name_from, "Channels", std::to_string(Channels)).c_str());
-	MusicVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "MusicVolume", std::to_string(MusicVolume)).c_str());
-	SoundVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "SoundVolume", std::to_string(SoundVolume)).c_str());
-	AmbientFactor = (float)std::atof(engine->packages->GetIniValue("System", name_from, "AmbientFactor", std::to_string(AmbientFactor)).c_str());
+	UseFilter.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseFilter");
+	UseSurround.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSurround");
+	UseStereo.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseStereo");
+	UseCDMusic.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseCDMusic");
+	UseDigitalMusic.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDigitalMusic");
+	UseSpatial.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSpatial");
+	UseReverb.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseReverb");
+	Use3dHardware.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Use3dHardware");
+	LowSoundQuality.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "LowSoundQuality");
+	ReverseStereo.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ReverseStereo");
+	Latency.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Latency");
+	OutputRate.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "OutputRate");
+	Channels.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Channels");
+	MusicVolume.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MusicVolume");
+	SoundVolume.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SoundVolume");
+	AmbientFactor.FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor");
+	/*
+	UseFilter = std::atoi(engine->packages->GetIniValue("System", name_from, "UseFilter", UseFilter.ToString()).c_str());
+	UseSurround = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSurround", UseSurround.ToString()).c_str());
+	UseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "UseStereo", UseStereo.ToString()).c_str());
+	UseCDMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseCDMusic", UseCDMusic.ToString()).c_str());
+	UseDigitalMusic = std::atoi(engine->packages->GetIniValue("System", name_from, "UseDigitalMusic", UseDigitalMusic.ToString()).c_str());
+	UseSpatial = std::atoi(engine->packages->GetIniValue("System", name_from, "UseSpatial", UseSpatial.ToString()).c_str());
+	UseReverb = std::atoi(engine->packages->GetIniValue("System", name_from, "UseReverb", UseReverb.ToString()).c_str());
+	Use3dHardware = std::atoi(engine->packages->GetIniValue("System", name_from, "Use3dHardware", Use3dHardware.ToString()).c_str());
+	LowSoundQuality = std::atoi(engine->packages->GetIniValue("System", name_from, "LowSoundQuality", LowSoundQuality.ToString()).c_str());
+	ReverseStereo = std::atoi(engine->packages->GetIniValue("System", name_from, "ReverseStereo", ReverseStereo.ToString()).c_str());
+	Latency = std::atoi(engine->packages->GetIniValue("System", name_from, "Latency", Latency.ToString()).c_str());
+	OutputRate = std::atoi(engine->packages->GetIniValue("System", name_from, "OutputRate", OutputRate.ToString()).c_str());
+	Channels = std::atoi(engine->packages->GetIniValue("System", name_from, "Channels", Channels.ToString()).c_str());
+	MusicVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "MusicVolume", MusicVolume.ToString()).c_str());
+	SoundVolume = std::atoi(engine->packages->GetIniValue("System", name_from, "SoundVolume", SoundVolume.ToString()).c_str());
+	AmbientFactor = (float)std::atof(engine->packages->GetIniValue("System", name_from, "AmbientFactor", AmbientFactor.ToString()).c_str());
+	*/
 }
 
 void USurrealAudioDevice::SaveProperties()
 {
-	engine->packages->SetIniValue("System", Class, "UseFilter", std::to_string(UseFilter));
-	engine->packages->SetIniValue("System", Class, "UseSurround", std::to_string(UseSurround));
-	engine->packages->SetIniValue("System", Class, "UseStereo", std::to_string(UseStereo));
-	engine->packages->SetIniValue("System", Class, "UseCDMusic", std::to_string(UseCDMusic));
-	engine->packages->SetIniValue("System", Class, "UseDigitalMusic", std::to_string(UseDigitalMusic));
-	engine->packages->SetIniValue("System", Class, "UseSpatial", std::to_string(UseSpatial));
-	engine->packages->SetIniValue("System", Class, "UseReverb", std::to_string(UseReverb));
-	engine->packages->SetIniValue("System", Class, "Use3dHardware", std::to_string(Use3dHardware));
-	engine->packages->SetIniValue("System", Class, "LowSoundQuality", std::to_string(LowSoundQuality));
-	engine->packages->SetIniValue("System", Class, "ReverseStereo", std::to_string(ReverseStereo));
-	engine->packages->SetIniValue("System", Class, "Latency", std::to_string(Latency));
-	engine->packages->SetIniValue("System", Class, "OutputRate", std::to_string(OutputRate));
-	engine->packages->SetIniValue("System", Class, "Channels", std::to_string(Channels));
-	engine->packages->SetIniValue("System", Class, "MusicVolume", std::to_string(MusicVolume));
-	engine->packages->SetIniValue("System", Class, "SoundVolume", std::to_string(SoundVolume));
-	engine->packages->SetIniValue("System", Class, "AmbientFactor", std::to_string(AmbientFactor));
+	engine->packages->SetIniValue("System", Class, "UseFilter", UseFilter.ToString());
+	engine->packages->SetIniValue("System", Class, "UseSurround", UseSurround.ToString());
+	engine->packages->SetIniValue("System", Class, "UseStereo", UseStereo.ToString());
+	engine->packages->SetIniValue("System", Class, "UseCDMusic", UseCDMusic.ToString());
+	engine->packages->SetIniValue("System", Class, "UseDigitalMusic", UseDigitalMusic.ToString());
+	engine->packages->SetIniValue("System", Class, "UseSpatial", UseSpatial.ToString());
+	engine->packages->SetIniValue("System", Class, "UseReverb", UseReverb.ToString());
+	engine->packages->SetIniValue("System", Class, "Use3dHardware", Use3dHardware.ToString());
+	engine->packages->SetIniValue("System", Class, "LowSoundQuality", LowSoundQuality.ToString());
+	engine->packages->SetIniValue("System", Class, "ReverseStereo", ReverseStereo.ToString());
+	engine->packages->SetIniValue("System", Class, "Latency", Latency.ToString());
+	engine->packages->SetIniValue("System", Class, "OutputRate", OutputRate.ToString());
+	engine->packages->SetIniValue("System", Class, "Channels", Channels.ToString());
+	engine->packages->SetIniValue("System", Class, "MusicVolume", MusicVolume.ToString());
+	engine->packages->SetIniValue("System", Class, "SoundVolume", SoundVolume.ToString());
+	engine->packages->SetIniValue("System", Class, "AmbientFactor", AmbientFactor.ToString());
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -2,6 +2,7 @@
 
 #include "UObject.h"
 #include "UClient.h"
+#include "Package/IniProperty.h"
 
 class USubsystem : public UObject
 {
@@ -68,11 +69,11 @@ public:
 	using URenderDevice::URenderDevice;
 
 	std::string Class = "Engine.SurrealRenderDevice";
-	bool Translucency = true;
-	bool VolumetricLighting = true;
-	bool ShinySurfaces = true;
-	bool Coronas = true;
-	bool HighDetailActors = true;
+	IniProperty<bool> Translucency = true;
+	IniProperty<bool> VolumetricLighting = true;
+	IniProperty<bool> ShinySurfaces = true;
+	IniProperty<bool> Coronas = true;
+	IniProperty<bool> HighDetailActors = true;
 
 	void LoadProperties(const NameString& from = "") override;
 	void SaveProperties() override;
@@ -87,22 +88,22 @@ public:
 	using UAudioSubsystem::UAudioSubsystem;
 
 	std::string Class = "Engine.SurrealAudioDevice";
-	bool UseFilter = true;
-	bool UseSurround = true;
-	bool UseStereo = true;
-	bool UseCDMusic = false;
-	bool UseDigitalMusic = true;
-	bool UseSpatial = true;
-	bool UseReverb = true;
-	bool Use3dHardware = true;
-	bool LowSoundQuality = false;
-	bool ReverseStereo = false;
-	int Latency = 40;
-	int OutputRate = 44100;
-	int Channels = 16;
-	uint8_t MusicVolume = 160;
-	uint8_t SoundVolume = 200;
-	float AmbientFactor = 0.7f;
+	IniProperty<bool> UseFilter = true;
+	IniProperty<bool> UseSurround = true;
+	IniProperty<bool> UseStereo = true;
+	IniProperty<bool> UseCDMusic = false;
+	IniProperty<bool> UseDigitalMusic = true;
+	IniProperty<bool> UseSpatial = true;
+	IniProperty<bool> UseReverb = true;
+	IniProperty<bool> Use3dHardware = true;
+	IniProperty<bool> LowSoundQuality = false;
+	IniProperty<bool> ReverseStereo = false;
+	IniProperty<int> Latency = 40;
+	IniProperty<int> OutputRate = 44100;
+	IniProperty<int> Channels = 16;
+	IniProperty<uint8_t> MusicVolume = 160;
+	IniProperty<uint8_t> SoundVolume = 200;
+	IniProperty<float> AmbientFactor = 0.7f;
 
 	void LoadProperties(const NameString& from = "") override;
 	void SaveProperties() override;

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -129,21 +129,21 @@ public:
 	using UClient::UClient;
 
 	std::string Class = "Engine.SurrealClient";
-	bool StartupFullscreen = false;
-	int WindowedViewportX = 1920;
-	int WindowedViewportY = 1080;
-	int WindowedColorBits = 32;
-	int FullscreenViewportX = 0;
-	int FullscreenViewportY = 0;
-	int FullscreenColorBits = 32;
-	float Brightness = 0.5f;
-	bool UseJoystick = false;
-	bool UseDirectInput = true;
-	int MinDesiredFrameRate = 200;
-	bool Decals = true;
-	bool NoDynamicLights = false;
-	std::string TextureDetail = "High";
-	std::string SkinDetail = "High";
+	IniProperty<bool> StartupFullscreen = false;
+	IniProperty<int> WindowedViewportX = 1920;
+	IniProperty<int> WindowedViewportY = 1080;
+	IniProperty<int> WindowedColorBits = 32;
+	IniProperty<int> FullscreenViewportX = 0;
+	IniProperty<int> FullscreenViewportY = 0;
+	IniProperty<int> FullscreenColorBits = 32;
+	IniProperty<float> Brightness = 0.5f;
+	IniProperty<bool> UseJoystick = false;
+	IniProperty<bool> UseDirectInput = true;
+	IniProperty<int> MinDesiredFrameRate = 200;
+	IniProperty<bool> Decals = true;
+	IniProperty<bool> NoDynamicLights = false;
+	IniProperty<std::string> TextureDetail = "High";
+	IniProperty<std::string> SkinDetail = "High";
 
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -145,6 +145,9 @@ public:
 	IniProperty<std::string> TextureDetail = "High";
 	IniProperty<std::string> SkinDetail = "High";
 
+	void LoadProperties(const NameString& from = "");
+	void SaveProperties();
+
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;
 };

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -7,6 +7,9 @@ class USubsystem : public UObject
 {
 public:
 	using UObject::UObject;
+
+	virtual void LoadProperties(const NameString& from = "") {}
+	virtual void SaveProperties() {}
 };
 
 class ULanguage : public UObject
@@ -71,6 +74,9 @@ public:
 	bool Coronas = true;
 	bool HighDetailActors = true;
 
+	void LoadProperties(const NameString& from = "") override;
+	void SaveProperties() override;
+
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;
 };
@@ -97,6 +103,9 @@ public:
 	uint8_t MusicVolume = 160;
 	uint8_t SoundVolume = 200;
 	float AmbientFactor = 0.7f;
+
+	void LoadProperties(const NameString& from = "") override;
+	void SaveProperties() override;
 
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -69,11 +69,11 @@ public:
 	using URenderDevice::URenderDevice;
 
 	std::string Class = "Engine.SurrealRenderDevice";
-	IniProperty<bool> Translucency = true;
-	IniProperty<bool> VolumetricLighting = true;
-	IniProperty<bool> ShinySurfaces = true;
-	IniProperty<bool> Coronas = true;
-	IniProperty<bool> HighDetailActors = true;
+	bool Translucency = true;
+	bool VolumetricLighting = true;
+	bool ShinySurfaces = true;
+	bool Coronas = true;
+	bool HighDetailActors = true;
 
 	void LoadProperties(const NameString& from = "") override;
 	void SaveProperties() override;
@@ -88,22 +88,22 @@ public:
 	using UAudioSubsystem::UAudioSubsystem;
 
 	std::string Class = "Engine.SurrealAudioDevice";
-	IniProperty<bool> UseFilter = true;
-	IniProperty<bool> UseSurround = true;
-	IniProperty<bool> UseStereo = true;
-	IniProperty<bool> UseCDMusic = false;
-	IniProperty<bool> UseDigitalMusic = true;
-	IniProperty<bool> UseSpatial = true;
-	IniProperty<bool> UseReverb = true;
-	IniProperty<bool> Use3dHardware = true;
-	IniProperty<bool> LowSoundQuality = false;
-	IniProperty<bool> ReverseStereo = false;
-	IniProperty<int> Latency = 40;
-	IniProperty<int> OutputRate = 44100;
-	IniProperty<int> Channels = 16;
-	IniProperty<uint8_t> MusicVolume = 160;
-	IniProperty<uint8_t> SoundVolume = 200;
-	IniProperty<float> AmbientFactor = 0.7f;
+	bool UseFilter = true;
+	bool UseSurround = true;
+	bool UseStereo = true;
+	bool UseCDMusic = false;
+	bool UseDigitalMusic = true;
+	bool UseSpatial = true;
+	bool UseReverb = true;
+	bool Use3dHardware = true;
+	bool LowSoundQuality = false;
+	bool ReverseStereo = false;
+	int Latency = 40;
+	int OutputRate = 44100;
+	int Channels = 16;
+	uint8_t MusicVolume = 160;
+	uint8_t SoundVolume = 200;
+	float AmbientFactor = 0.7f;
 
 	void LoadProperties(const NameString& from = "") override;
 	void SaveProperties() override;
@@ -129,21 +129,21 @@ public:
 	using UClient::UClient;
 
 	std::string Class = "Engine.SurrealClient";
-	IniProperty<bool> StartupFullscreen = false;
-	IniProperty<int> WindowedViewportX = 1920;
-	IniProperty<int> WindowedViewportY = 1080;
-	IniProperty<int> WindowedColorBits = 32;
-	IniProperty<int> FullscreenViewportX = 0;
-	IniProperty<int> FullscreenViewportY = 0;
-	IniProperty<int> FullscreenColorBits = 32;
-	IniProperty<float> Brightness = 0.5f;
-	IniProperty<bool> UseJoystick = false;
-	IniProperty<bool> UseDirectInput = true;
-	IniProperty<int> MinDesiredFrameRate = 200;
-	IniProperty<bool> Decals = true;
-	IniProperty<bool> NoDynamicLights = false;
-	IniProperty<std::string> TextureDetail = "High";
-	IniProperty<std::string> SkinDetail = "High";
+	bool StartupFullscreen = false;
+	int WindowedViewportX = 1920;
+	int WindowedViewportY = 1080;
+	int WindowedColorBits = 32;
+	int FullscreenViewportX = 0;
+	int FullscreenViewportY = 0;
+	int FullscreenColorBits = 32;
+	float Brightness = 0.5f;
+	bool UseJoystick = false;
+	bool UseDirectInput = true;
+	int MinDesiredFrameRate = 200;
+	bool Decals = true;
+	bool NoDynamicLights = false;
+	std::string TextureDetail = "High";
+	std::string SkinDetail = "High";
 
 	void LoadProperties(const NameString& from = "");
 	void SaveProperties();


### PR DESCRIPTION
* `IniFile`s can now change the values, and write everything to a given file
* USubsystem and USurrealClient classes now make use of the new `IniPropertyConverter` class to convert values from the ini file to the appropriate types
* SurrealEngine now tries to load values from `SE-[GameName].ini` and `SE-User.ini` respectively. If these files aren't found, then SurrealEngine will import the original game's ini files instead.
* Map file (and save file) extensions are now read from the ini (instead of hardcoded `.unr`)
* Specifying the map extension in `GetDefaultURL()` is now optional