### PR TITLE
Small additions and fixes to IniPropertyConverter

### DIFF
--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -8,15 +8,33 @@ int IniPropertyConverter<int>::FromString(const std::string& valueString)
 }
 
 template<>
+int IniPropertyConverter<int>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const int& default_value)
+{
+	return std::stoi(iniFile.GetValue(section, keyName, ToString(default_value)));
+}
+
+template<>
 float IniPropertyConverter<float>::FromString(const std::string& valueString)
 {
 	return std::stof(valueString);
 }
 
 template<>
+float IniPropertyConverter<float>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const float& default_value)
+{
+	return std::stof(iniFile.GetValue(section, keyName, ToString(default_value)));
+}
+
+template<>
 uint8_t IniPropertyConverter<uint8_t>::FromString(const std::string& valueString)
 {
 	return (uint8_t)std::stoul(valueString);
+}
+
+template<>
+uint8_t IniPropertyConverter<uint8_t>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const uint8_t& default_value)
+{
+	return std::stoul(iniFile.GetValue(section, keyName, ToString(default_value)));
 }
 
 template<>
@@ -27,7 +45,13 @@ bool IniPropertyConverter<bool>::FromString(const std::string& valueString)
 	else if (valueString == "False" || valueString == "false" || valueString == "0")
 		return false;
 	else
-		throw std::runtime_error("Encountered non-boolean value: " + valueString);
+		throw std::runtime_error("Encountered a non-boolean value: " + valueString);
+}
+
+template<>
+bool IniPropertyConverter<bool>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const bool& default_value)
+{
+	return FromString(iniFile.GetValue(section, keyName, ToString(default_value)));
 }
 
 template<>
@@ -36,3 +60,25 @@ std::string IniPropertyConverter<std::string>::FromString(const std::string& val
 	return valueString;
 }
 
+template<>
+std::string IniPropertyConverter<std::string>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const std::string& default_value)
+{
+	return iniFile.GetValue(section, keyName, default_value);
+}
+
+template<>
+AudioFrequency IniPropertyConverter<AudioFrequency>::FromString(const std::string& valueString)
+{
+	if (auto pos = valueString.find("Hz"); pos != std::string::npos)
+	{
+		int frequency = std::stoi(valueString.substr(0, pos));
+		return AudioFrequency(frequency);
+	}
+	throw std::runtime_error("Invalid value " + valueString + " for changing frequency.");
+}
+
+template<>
+AudioFrequency IniPropertyConverter<AudioFrequency>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const AudioFrequency& default_value)
+{
+	return FromString(iniFile.GetValue(section, keyName, ToString(default_value)));
+}

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -14,6 +14,14 @@ int IniPropertyConverter<int>::FromIniFile(const IniFile& iniFile, const NameStr
 }
 
 template<>
+std::string IniPropertyConverter<int>::ToString(const int& value)
+{
+	return std::to_string(value);
+}
+
+//====================================================================
+
+template<>
 float IniPropertyConverter<float>::FromString(const std::string& valueString)
 {
 	return std::stof(valueString);
@@ -26,6 +34,14 @@ float IniPropertyConverter<float>::FromIniFile(const IniFile& iniFile, const Nam
 }
 
 template<>
+std::string IniPropertyConverter<float>::ToString(const float& value)
+{
+	return std::to_string(value);
+}
+
+//====================================================================
+
+template<>
 uint8_t IniPropertyConverter<uint8_t>::FromString(const std::string& valueString)
 {
 	return (uint8_t)std::stoul(valueString);
@@ -36,6 +52,14 @@ uint8_t IniPropertyConverter<uint8_t>::FromIniFile(const IniFile& iniFile, const
 {
 	return std::stoul(iniFile.GetValue(section, keyName, ToString(default_value)));
 }
+
+template<>
+std::string IniPropertyConverter<uint8_t>::ToString(const uint8_t& value)
+{
+	return std::to_string(value);
+}
+
+//====================================================================
 
 template<>
 bool IniPropertyConverter<bool>::FromString(const std::string& valueString)
@@ -55,6 +79,14 @@ bool IniPropertyConverter<bool>::FromIniFile(const IniFile& iniFile, const NameS
 }
 
 template<>
+std::string IniPropertyConverter<bool>::ToString(const bool& value)
+{
+	return value ? "True" : "False";
+}
+
+//====================================================================
+
+template<>
 std::string IniPropertyConverter<std::string>::FromString(const std::string& valueString)
 {
 	return valueString;
@@ -65,6 +97,14 @@ std::string IniPropertyConverter<std::string>::FromIniFile(const IniFile& iniFil
 {
 	return iniFile.GetValue(section, keyName, default_value);
 }
+
+template<>
+std::string IniPropertyConverter<std::string>::ToString(const std::string& value)
+{
+	return value;
+}
+
+//====================================================================
 
 template<>
 AudioFrequency IniPropertyConverter<AudioFrequency>::FromString(const std::string& valueString)
@@ -81,4 +121,10 @@ template<>
 AudioFrequency IniPropertyConverter<AudioFrequency>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const AudioFrequency& default_value)
 {
 	return FromString(iniFile.GetValue(section, keyName, ToString(default_value)));
+}
+
+template<>
+std::string IniPropertyConverter<AudioFrequency>::ToString(const AudioFrequency& value)
+{
+	return std::to_string(value.frequency) + "Hz";
 }

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -8,15 +8,15 @@ int IniPropertyConverter<int>::FromString(const std::string& valueString)
 }
 
 template<>
-int IniPropertyConverter<int>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const int& default_value)
-{
-	return std::stoi(iniFile.GetValue(section, keyName, ToString(default_value)));
-}
-
-template<>
 std::string IniPropertyConverter<int>::ToString(const int& value)
 {
 	return std::to_string(value);
+}
+
+template<>
+int IniPropertyConverter<int>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const int& default_value)
+{
+	return std::stoi(iniFile.GetValue(section, keyName, ToString(default_value)));
 }
 
 //====================================================================
@@ -28,15 +28,15 @@ float IniPropertyConverter<float>::FromString(const std::string& valueString)
 }
 
 template<>
-float IniPropertyConverter<float>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const float& default_value)
-{
-	return std::stof(iniFile.GetValue(section, keyName, ToString(default_value)));
-}
-
-template<>
 std::string IniPropertyConverter<float>::ToString(const float& value)
 {
 	return std::to_string(value);
+}
+
+template<>
+float IniPropertyConverter<float>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const float& default_value)
+{
+	return std::stof(iniFile.GetValue(section, keyName, ToString(default_value)));
 }
 
 //====================================================================
@@ -48,15 +48,15 @@ uint8_t IniPropertyConverter<uint8_t>::FromString(const std::string& valueString
 }
 
 template<>
-uint8_t IniPropertyConverter<uint8_t>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const uint8_t& default_value)
-{
-	return std::stoul(iniFile.GetValue(section, keyName, ToString(default_value)));
-}
-
-template<>
 std::string IniPropertyConverter<uint8_t>::ToString(const uint8_t& value)
 {
 	return std::to_string(value);
+}
+
+template<>
+uint8_t IniPropertyConverter<uint8_t>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const uint8_t& default_value)
+{
+	return std::stoul(iniFile.GetValue(section, keyName, ToString(default_value)));
 }
 
 //====================================================================
@@ -69,19 +69,20 @@ bool IniPropertyConverter<bool>::FromString(const std::string& valueString)
 	else if (valueString == "False" || valueString == "false" || valueString == "0")
 		return false;
 	else
-		throw std::runtime_error("Encountered a non-boolean value: " + valueString);
+		throw std::invalid_argument("Encountered a non-boolean value: " + valueString);
+}
+
+
+template<>
+std::string IniPropertyConverter<bool>::ToString(const bool& value)
+{
+	return value ? "True" : "False";
 }
 
 template<>
 bool IniPropertyConverter<bool>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const bool& default_value)
 {
 	return FromString(iniFile.GetValue(section, keyName, ToString(default_value)));
-}
-
-template<>
-std::string IniPropertyConverter<bool>::ToString(const bool& value)
-{
-	return value ? "True" : "False";
 }
 
 //====================================================================
@@ -93,15 +94,15 @@ std::string IniPropertyConverter<std::string>::FromString(const std::string& val
 }
 
 template<>
-std::string IniPropertyConverter<std::string>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const std::string& default_value)
-{
-	return iniFile.GetValue(section, keyName, default_value);
-}
-
-template<>
 std::string IniPropertyConverter<std::string>::ToString(const std::string& value)
 {
 	return value;
+}
+
+template<>
+std::string IniPropertyConverter<std::string>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const std::string& default_value)
+{
+	return iniFile.GetValue(section, keyName, default_value);
 }
 
 //====================================================================
@@ -114,17 +115,17 @@ AudioFrequency IniPropertyConverter<AudioFrequency>::FromString(const std::strin
 		int frequency = std::stoi(valueString.substr(0, pos));
 		return AudioFrequency(frequency);
 	}
-	throw std::runtime_error("Invalid value " + valueString + " for changing frequency.");
-}
-
-template<>
-AudioFrequency IniPropertyConverter<AudioFrequency>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const AudioFrequency& default_value)
-{
-	return FromString(iniFile.GetValue(section, keyName, ToString(default_value)));
+	throw std::invalid_argument("Invalid value '" + valueString + "' for changing frequency. The value must be a number that ends with 'Hz'.");
 }
 
 template<>
 std::string IniPropertyConverter<AudioFrequency>::ToString(const AudioFrequency& value)
 {
 	return std::to_string(value.frequency) + "Hz";
+}
+
+template<>
+AudioFrequency IniPropertyConverter<AudioFrequency>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const AudioFrequency& default_value)
+{
+	return FromString(iniFile.GetValue(section, keyName, ToString(default_value)));
 }

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "IniFile.h"
+#include "UObject/USound.h"
 
 template <typename T>
 class IniPropertyConverter
@@ -11,10 +12,19 @@ public:
 	static std::string ToString(const T& value) { return std::to_string(value); }
 	static T FromString(const std::string& valueString);
 	static T FromString(const char* valueString) { return FromString(std::string(valueString)); }
-	static T FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName)
-	{
-		return FromString(iniFile.GetValue(section, keyName));
-	}
+	static T FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const T& default_value);
 
 	IniPropertyConverter() = delete;
 };
+
+template<>
+std::string IniPropertyConverter<AudioFrequency>::ToString(const AudioFrequency& value)
+{
+	return std::to_string(value.frequency) + "Hz";
+}
+
+template<>
+std::string IniPropertyConverter<bool>::ToString(const bool& value)
+{
+	return value ? "True" : "False";
+}

--- a/SurrealEngine/Package/IniProperty.h
+++ b/SurrealEngine/Package/IniProperty.h
@@ -9,22 +9,10 @@ template <typename T>
 class IniPropertyConverter
 {
 public:
-	static std::string ToString(const T& value) { return std::to_string(value); }
+	static std::string ToString(const T& value);
 	static T FromString(const std::string& valueString);
 	static T FromString(const char* valueString) { return FromString(std::string(valueString)); }
 	static T FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const T& default_value);
 
 	IniPropertyConverter() = delete;
 };
-
-template<>
-std::string IniPropertyConverter<AudioFrequency>::ToString(const AudioFrequency& value)
-{
-	return std::to_string(value.frequency) + "Hz";
-}
-
-template<>
-std::string IniPropertyConverter<bool>::ToString(const bool& value)
-{
-	return value ? "True" : "False";
-}

--- a/SurrealEngine/UObject/USound.h
+++ b/SurrealEngine/UObject/USound.h
@@ -10,6 +10,13 @@ public:
 	uint64_t LoopEnd = 0;
 };
 
+class AudioFrequency
+{
+public:
+	AudioFrequency(int frequency) : frequency(frequency) {}
+	int frequency = 0;
+};
+
 class USound : public UObject
 {
 public:

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -48,11 +48,11 @@ void USurrealRenderDevice::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	Translucency = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Translucency");
-	VolumetricLighting = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "VolumetricLighting");
-	ShinySurfaces = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ShinySurfaces");
-	Coronas = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Coronas");
-	HighDetailActors = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "HighDetailActors");
+	Translucency = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Translucency", Translucency);
+	VolumetricLighting = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "VolumetricLighting", VolumetricLighting);
+	ShinySurfaces = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ShinySurfaces", ShinySurfaces);
+	Coronas = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Coronas", Coronas);
+	HighDetailActors = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "HighDetailActors", HighDetailActors);
 }
 
 void USurrealRenderDevice::SaveProperties()
@@ -93,7 +93,7 @@ std::string USurrealAudioDevice::GetPropertyAsString(const NameString& propertyN
 	else if (propertyName == "Latency")
 		return IniPropertyConverter<int>::ToString(Latency);
 	else if (propertyName == "OutputRate")
-		return IniPropertyConverter<int>::ToString(OutputRate);
+		return IniPropertyConverter<AudioFrequency>::ToString(OutputRate);
 	else if (propertyName == "Channels")
 		return IniPropertyConverter<int>::ToString(Channels);
 	else if (propertyName == "MusicVolume")
@@ -132,7 +132,7 @@ void USurrealAudioDevice::SetPropertyFromString(const NameString& propertyName, 
 	else if (propertyName == "Latency")
 		Latency = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "OutputRate")
-		OutputRate = IniPropertyConverter<int>::FromString(value);
+		OutputRate = IniPropertyConverter<AudioFrequency>::FromString(value);
 	else if (propertyName == "Channels")
 		Channels = IniPropertyConverter<int>::FromString(value);
 	else if (propertyName == "MusicVolume")
@@ -154,22 +154,22 @@ void USurrealAudioDevice::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	UseFilter = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseFilter");
-	UseSurround = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSurround");
-	UseStereo = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseStereo");
-	UseCDMusic = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseCDMusic");
-	UseDigitalMusic = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDigitalMusic");
-	UseSpatial = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSpatial");
-	UseReverb = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseReverb");
-	Use3dHardware = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Use3dHardware");
-	LowSoundQuality = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "LowSoundQuality");
-	ReverseStereo = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ReverseStereo");
-	Latency = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Latency");
-	OutputRate = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "OutputRate");
-	Channels = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Channels");
-	MusicVolume = IniPropertyConverter<uint8_t>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MusicVolume");
-	SoundVolume = IniPropertyConverter<uint8_t>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SoundVolume");
-	AmbientFactor = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor");
+	UseFilter = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseFilter", UseFilter);
+	UseSurround = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSurround", UseSurround);
+	UseStereo = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseStereo", UseStereo);
+	UseCDMusic = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseCDMusic", UseCDMusic);
+	UseDigitalMusic = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDigitalMusic", UseDigitalMusic);
+	UseSpatial = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseSpatial", UseSpatial);
+	UseReverb = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseReverb", UseReverb);
+	Use3dHardware = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Use3dHardware", Use3dHardware);
+	LowSoundQuality = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "LowSoundQuality", LowSoundQuality);
+	ReverseStereo = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "ReverseStereo", ReverseStereo);
+	Latency = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Latency", Latency);
+	OutputRate = IniPropertyConverter<AudioFrequency>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "OutputRate", OutputRate);
+	Channels = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Channels", Channels);
+	MusicVolume = IniPropertyConverter<uint8_t>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MusicVolume", MusicVolume);
+	SoundVolume = IniPropertyConverter<uint8_t>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SoundVolume", SoundVolume);
+	AmbientFactor = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor", AmbientFactor);
 }
 
 void USurrealAudioDevice::SaveProperties()
@@ -185,7 +185,7 @@ void USurrealAudioDevice::SaveProperties()
 	engine->packages->SetIniValue("System", Class, "LowSoundQuality", IniPropertyConverter<bool>::ToString(LowSoundQuality));
 	engine->packages->SetIniValue("System", Class, "ReverseStereo", IniPropertyConverter<bool>::ToString(ReverseStereo));
 	engine->packages->SetIniValue("System", Class, "Latency", IniPropertyConverter<int>::ToString(Latency));
-	engine->packages->SetIniValue("System", Class, "OutputRate", IniPropertyConverter<int>::ToString(OutputRate));
+	engine->packages->SetIniValue("System", Class, "OutputRate", IniPropertyConverter<AudioFrequency>::ToString(OutputRate));
 	engine->packages->SetIniValue("System", Class, "Channels", IniPropertyConverter<int>::ToString(Channels));
 	engine->packages->SetIniValue("System", Class, "MusicVolume", IniPropertyConverter<uint8_t>::ToString(MusicVolume));
 	engine->packages->SetIniValue("System", Class, "SoundVolume", IniPropertyConverter<uint8_t>::ToString(SoundVolume));
@@ -218,21 +218,21 @@ void USurrealClient::LoadProperties(const NameString& from)
 	if (from == "")
 		name_from = NameString(Class);
 
-	StartupFullscreen = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "StartupFullscreen");
-	WindowedViewportX = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportX");
-	WindowedViewportY = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportY");
-	WindowedColorBits = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedColorBits");
-	FullscreenViewportX = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportX");
-	FullscreenViewportY = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportY");
-	FullscreenColorBits = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenColorBits");
-	Brightness = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Brightness");
-	UseJoystick = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseJoystick");
-	UseDirectInput = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDirectInput");
-	MinDesiredFrameRate = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MinDesiredFrameRate");
-	Decals = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Decals");
-	NoDynamicLights = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "NoDynamicLights");
-	TextureDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "TextureDetail");
-	SkinDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SkinDetail");
+	StartupFullscreen = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "StartupFullscreen", StartupFullscreen);
+	WindowedViewportX = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportX", WindowedViewportX);
+	WindowedViewportY = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedViewportY", WindowedViewportY);
+	WindowedColorBits = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "WindowedColorBits", WindowedColorBits);
+	FullscreenViewportX = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportX", FullscreenViewportX);
+	FullscreenViewportY = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenViewportY", FullscreenViewportY);
+	FullscreenColorBits = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "FullscreenColorBits", FullscreenColorBits);
+	Brightness = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Brightness", Brightness);
+	UseJoystick = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseJoystick", UseJoystick);
+	UseDirectInput = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "UseDirectInput", UseDirectInput);
+	MinDesiredFrameRate = IniPropertyConverter<int>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "MinDesiredFrameRate", MinDesiredFrameRate);
+	Decals = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "Decals", Decals);
+	NoDynamicLights = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "NoDynamicLights", NoDynamicLights);
+	TextureDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "TextureDetail", TextureDetail);
+	SkinDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SkinDetail", SkinDetail);
 }
 
 void USurrealClient::SaveProperties()

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -3,6 +3,7 @@
 #include "UObject.h"
 #include "UClient.h"
 #include "Package/IniProperty.h"
+#include "USound.h"
 
 class USubsystem : public UObject
 {
@@ -99,7 +100,7 @@ public:
 	bool LowSoundQuality = false;
 	bool ReverseStereo = false;
 	int Latency = 40;
-	int OutputRate = 44100;
+	AudioFrequency OutputRate = 44100;
 	int Channels = 16;
 	uint8_t MusicVolume = 160;
 	uint8_t SoundVolume = 200;


### PR DESCRIPTION
* Handle values of the audio frequency type (e.g. "22050Hz") 
* Supply default values in case the key doesn't exist in ini, so the game doesn't crash