### PR TITLE
Misc. Improvements

### DIFF
--- a/SurrealEngine/Native/NPawn.cpp
+++ b/SurrealEngine/Native/NPawn.cpp
@@ -46,8 +46,9 @@ void NPawn::AddPawn(UObject* Self)
 
 void NPawn::CanSee(UObject* Self, UObject* Other, BitfieldBool& ReturnValue)
 {
-	engine->LogUnimplemented("Pawn.CanSee");
-	ReturnValue = false;
+	UPawn* selfPawn = UObject::Cast<UPawn>(Self);
+	UActor* otherActor = UObject::Cast<UActor>(Other);
+	ReturnValue = selfPawn->CanSee(otherActor);
 }
 
 void NPawn::CheckValidSkinPackage(const std::string& SkinPack, const std::string& MeshName, BitfieldBool& ReturnValue)
@@ -102,8 +103,9 @@ void NPawn::FindStairRotation(UObject* Self, float DeltaTime, int& ReturnValue)
 
 void NPawn::LineOfSightTo(UObject* Self, UObject* Other, BitfieldBool& ReturnValue)
 {
-	engine->LogUnimplemented("Pawn.LineOfSightTo(" + UObject::GetUClassName(Other).ToString() + ")");
-	ReturnValue = false;
+	UPawn* selfPawn = UObject::Cast<UPawn>(Self);
+	UActor* otherActor = UObject::Cast<UActor>(Other);
+	ReturnValue = selfPawn->LineOfSightTo(otherActor);
 }
 
 void NPawn::MoveTo(UObject* Self, const vec3& NewDestination, float* speed)

--- a/SurrealEngine/Render/RenderScene.cpp
+++ b/SurrealEngine/Render/RenderScene.cpp
@@ -62,13 +62,21 @@ void RenderSubsystem::DrawFrame(const vec3& location, const mat4& worldToView)
 	for (const DrawNodeInfo& nodeInfo : Scene.OpaqueNodes)
 		DrawNodeSurface(nodeInfo);
 	DrawDecals(&Scene.Frame);
+	DrawActors();
+	// Draw transparent surfaces last
 	for (auto it = Scene.TranslucentNodes.rbegin(); it != Scene.TranslucentNodes.rend(); ++it)
 		DrawNodeSurface(*it);
-	DrawActors();
 }
 
 void RenderSubsystem::DrawActors()
 {
+	// Sort the actors according to their distance to the camera
+	std::sort(Scene.Actors.begin(), Scene.Actors.end(), 
+		[&](UActor* actor1, UActor* actor2) { 
+			return length(Scene.ViewLocation - vec4(actor1->Location(), 1.0f)) > length(Scene.ViewLocation - vec4(actor2->Location(), 1.0f));
+		}
+	);
+
 	for (UActor* actor : Scene.Actors)
 	{
 		EDrawType dt = (EDrawType)actor->DrawType();

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -16,7 +16,7 @@ UActor* UActor::Spawn(UClass* SpawnClass, UActor* SpawnOwner, NameString SpawnTa
 {
 	// To do: return null if spawn location isn't valid
 
-	if (!SpawnClass) // To do: return null if spawn class is abstract
+	if (!SpawnClass || SpawnClass->ClsFlags & ClassFlags::Abstract)
 	{
 		return nullptr;
 	}

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -1910,6 +1910,50 @@ bool UPawn::PointReachable(vec3 aPoint)
 	return TryMove(delta, true).Fraction == 1.0f;
 }
 
+bool UPawn::LineOfSightTo(UActor* other)
+{
+	if (!other)
+		return false;
+
+	vec3 eye_pos = Location();
+	eye_pos.z += BaseEyeHeight();
+
+	auto& origin = other->Location();
+	auto top = origin + vec3{0.f, 0.f, other->CollisionHeight() / 2};
+	auto bottom = origin - vec3{ 0.f, 0.f, other->CollisionHeight() / 2 };
+
+	return FastTrace(origin, eye_pos) || FastTrace(top, eye_pos) || FastTrace(bottom, eye_pos);
+}
+
+bool UPawn::CanSee(UActor* other)
+{
+	if (!other)
+		return false;
+
+	// Two fields to keep in mind of:
+	// float SightRadius: Maximum seeing distance
+	// float PeripheralVision: Cosine of limits of peripheral vision
+
+	auto& origin = other->Location();
+	auto top = origin + vec3{ 0.f, 0.f, other->CollisionHeight() / 2 };
+	auto bottom = origin - vec3{ 0.f, 0.f, other->CollisionHeight() / 2 };
+
+	vec3 eye_pos = Location();
+	eye_pos.z += BaseEyeHeight();
+
+	// Cannot see if the actor is too far away from the sight radius
+	if (length(origin - eye_pos) > SightRadius())
+		return false;
+
+	// Cannot see if the actor is outside of the peripheral vision angles
+	auto orientation = Coords::Rotation(Rotation()).XAxis;
+
+	if (abs(dot(orientation, origin)) > PeripheralVision())
+		return false;
+
+	return FastTrace(origin, eye_pos) || FastTrace(top, eye_pos) || FastTrace(bottom, eye_pos);
+}
+
 bool UPawn::CanHearNoise(UActor* source, float loudness)
 {
 	UPawn* noisePawn = UObject::Cast<UPawn>(source->Instigator());

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -14,8 +14,6 @@ static std::string tickEventName = "Tick";
 
 UActor* UActor::Spawn(UClass* SpawnClass, UActor* SpawnOwner, NameString SpawnTag, vec3* SpawnLocation, Rotator* SpawnRotation)
 {
-	// To do: return null if spawn location isn't valid
-
 	if (!SpawnClass || SpawnClass->ClsFlags & ClassFlags::Abstract)
 	{
 		return nullptr;

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -1585,6 +1585,10 @@ public:
 	bool TickRotateTo(const vec3& target);
 	bool TickMoveTo(const vec3& target);
 
+	// Returns true if any of the several points of other is visible (origin, top, bottom)
+	bool LineOfSightTo(UActor* other);
+	// Similar to LineOfSightTo() but takes the Pawn's peripheral vision into account (SightRadius and PeripheralVision)
+	bool CanSee(UActor* other);
 	bool CanHearNoise(UActor* source, float loudness);
 	bool ActorReachable(UActor* anActor);
 	bool PointReachable(vec3 aPoint);

--- a/SurrealEngine/UObject/UClass.h
+++ b/SurrealEngine/UObject/UClass.h
@@ -170,8 +170,9 @@ enum class ClassFlags : uint32_t
 	NativeReplication = 0x00800, // Replication handled in C++
 };
 
-static const uint32_t operator&(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) & uint32_t(rhs); }
-static const uint32_t operator|(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) | uint32_t(rhs); }
+static uint32_t operator&(const ClassFlags lhs, const ClassFlags rhs) { return uint32_t(lhs) & uint32_t(rhs); }
+static uint32_t operator|(const ClassFlags lhs, const ClassFlags rhs) { return uint32_t(lhs) | uint32_t(rhs); }
+static uint32_t operator^(const ClassFlags lhs, const ClassFlags rhs) { return uint32_t(lhs) ^ uint32_t(rhs); }
 
 class UClass : public UState
 {

--- a/SurrealEngine/UObject/UClass.h
+++ b/SurrealEngine/UObject/UClass.h
@@ -170,6 +170,9 @@ enum class ClassFlags : uint32_t
 	NativeReplication = 0x00800, // Replication handled in C++
 };
 
+uint32_t operator&(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) & uint32_t(rhs); }
+uint32_t operator|(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) | uint32_t(rhs); }
+
 class UClass : public UState
 {
 public:

--- a/SurrealEngine/UObject/UClass.h
+++ b/SurrealEngine/UObject/UClass.h
@@ -170,8 +170,8 @@ enum class ClassFlags : uint32_t
 	NativeReplication = 0x00800, // Replication handled in C++
 };
 
-uint32_t operator&(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) & uint32_t(rhs); }
-uint32_t operator|(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) | uint32_t(rhs); }
+static const uint32_t operator&(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) & uint32_t(rhs); }
+static const uint32_t operator|(ClassFlags lhs, ClassFlags rhs) { return uint32_t(lhs) | uint32_t(rhs); }
 
 class UClass : public UState
 {


### PR DESCRIPTION
* `UActor::Spawn()` returns null when the Class is an abstract class
* Implement `UPawn::LineOfSightTo()` and `UPawn::CanSee()`
* Draw transparent surfaces always last, and sort the Actors in the scene relative to their distance to the camera. This fixes #56 