### PR TITLE
Improvements to IniFile class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,8 @@ set(THIRDPARTY_SOURCES
 	Thirdparty/dumb/include/internal/it.h
 	Thirdparty/dumb/include/internal/riff.h
 	Thirdparty/dumb/include/dumb.h
+	Thirdparty/MurmurHash3/MurmurHash3.cpp
+	Thirdparty/MurmurHash3/MurmurHash3.h
 	Thirdparty/resample/CDSPSincFilterGen.h
 	Thirdparty/resample/CDSPHBDownsampler.h
 	Thirdparty/resample/CDSPResampler.h

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -792,7 +792,7 @@ void Engine::LoadKeybindings()
 
 	for (int i = 0; i < 40; i++)
 	{
-		std::string alias = packages->GetIniValue("user", "Engine.Input", "Aliases", i);
+		std::string alias = packages->GetIniValue("user", "Engine.Input", "Aliases", "", i);
 
 		// Total trash parsing, but it will do for the aliases I have! Feel free to improve it!
 		std::string commandStart = "(Command=\"";

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -3,6 +3,55 @@
 #include "NameString.h"
 #include <map>
 
+class IniKey
+{
+public:
+	IniKey() = default;
+	IniKey(const std::string& _name, const uint32_t _hash);
+	IniKey(const IniKey& other);
+
+	uint32_t GetHash() const;
+	const std::string& GetName() const;
+	const std::vector<std::string>& GetValues() const;
+	bool GetIndexed() const;
+
+	std::string GetValue(const int index = 0) const;
+
+	int SetValue(const std::string& newValue, const int index = 0);
+	int SetValues(const std::vector<std::string>& newValues);
+
+	int SetIndexed(bool newIndexed);
+
+private:
+	std::string name;
+	uint32_t hash;
+	std::vector<std::string> values;
+	bool indexed = false;
+};
+
+class IniSection
+{
+public:
+	IniSection() = default;
+	IniSection(const std::string& _name, const uint32_t _hash);
+	IniSection(const IniSection& other);
+
+	uint32_t GetHash() const;
+	const std::string& GetName() const;
+	const std::vector<IniKey>& GetKeys() const;
+
+	std::string GetValue(const NameString& keyName, const std::string& defaultValue, const int index = 0) const;
+	std::vector<std::string> GetValues(const NameString& keyName, const std::vector<std::string>& defaultValues = {}) const;
+
+	bool SetValue(const NameString& keyName, const std::string& newValue, const int index = 0, const bool indexed = false);
+	bool SetValues(const NameString& keyName, const std::vector<std::string>& newValues, const bool indexed = false);
+
+private:
+	std::string name;
+	uint32_t hash;
+	std::vector<IniKey> keys;
+};
+
 class IniFile
 {
 public:
@@ -12,23 +61,26 @@ public:
 
 	bool IsModified() const { return isModified; }
 
-	std::vector<NameString> GetKeys(NameString sectionName) const;
-	std::string GetValue(NameString sectionName, NameString keyName, const int index = 0, std::string default_value="") const;
-	std::vector<std::string> GetValues(NameString sectionName, NameString keyName, std::vector<std::string> default_values = {}) const;
+	std::vector<NameString> GetKeys(const NameString& sectionName) const;
+	std::string GetValue(const NameString& sectionName, const NameString& keyName, const std::string& defaultValue = "", const int index = 0) const;
+	std::vector<std::string> GetValues(const NameString& sectionName, const NameString& keyName, const std::vector<std::string>& defaultValues = {}) const;
 
-	void SetValue(NameString sectionName, NameString keyName, const std::string& newValue);
-	void SetValues(NameString sectionName, NameString keyName, const std::vector<std::string>& newValues);
+	void SetValue(const NameString& sectionName, const NameString& keyName, const std::string& newValue, const int index = 0);
+	void SetValues(const NameString& sectionName, const NameString& keyName, const std::vector<std::string>& newValues);
 
 	// Saves values to the ini file the said values are loaded from
 	void SaveTo();
 	// Saves values to a specified file
-	void SaveTo(const std::string& filename); 
+	void SaveTo(const std::string& filename);
 
 private:
 	bool ReadLine(const std::string& text, size_t& pos, std::string& line);
 
-	bool isModified = false;
+	// Adds a new section, or gets the existing section
+	IniSection& AddUniqueSection(const std::string& sectionName);
+	const IniSection* FindSection(const std::string& sectionName) const;
 
+	bool isModified = false;
 	std::string ini_file_path;
-	std::map<NameString, std::map<NameString, std::vector<std::string>>> sections;
+	std::vector<IniSection> sections;
 };

--- a/SurrealEngine/Package/IniProperty.cpp
+++ b/SurrealEngine/Package/IniProperty.cpp
@@ -16,7 +16,7 @@ std::string IniPropertyConverter<int>::ToString(const int& value)
 template<>
 int IniPropertyConverter<int>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const int& default_value, const int index)
 {
-	return std::stoi(iniFile.GetValue(section, keyName, index, ToString(default_value)));
+	return std::stoi(iniFile.GetValue(section, keyName, ToString(default_value), index));
 }
 
 //====================================================================
@@ -36,7 +36,7 @@ std::string IniPropertyConverter<float>::ToString(const float& value)
 template<>
 float IniPropertyConverter<float>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const float& default_value, const int index)
 {
-	return std::stof(iniFile.GetValue(section, keyName, index, ToString(default_value)));
+	return std::stof(iniFile.GetValue(section, keyName, ToString(default_value), index));
 }
 
 //====================================================================
@@ -56,7 +56,7 @@ std::string IniPropertyConverter<uint8_t>::ToString(const uint8_t& value)
 template<>
 uint8_t IniPropertyConverter<uint8_t>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const uint8_t& default_value, const int index)
 {
-	return std::stoul(iniFile.GetValue(section, keyName, index, ToString(default_value)));
+	return std::stoul(iniFile.GetValue(section, keyName, ToString(default_value), index));
 }
 
 //====================================================================
@@ -82,7 +82,7 @@ std::string IniPropertyConverter<bool>::ToString(const bool& value)
 template<>
 bool IniPropertyConverter<bool>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const bool& default_value, const int index)
 {
-	return FromString(iniFile.GetValue(section, keyName, index, ToString(default_value)));
+	return FromString(iniFile.GetValue(section, keyName, ToString(default_value), index));
 }
 
 //====================================================================
@@ -102,7 +102,7 @@ std::string IniPropertyConverter<std::string>::ToString(const std::string& value
 template<>
 std::string IniPropertyConverter<std::string>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const std::string& default_value, const int index)
 {
-	return iniFile.GetValue(section, keyName, index, default_value);
+	return iniFile.GetValue(section, keyName, default_value, index);
 }
 
 //====================================================================
@@ -127,5 +127,5 @@ std::string IniPropertyConverter<AudioFrequency>::ToString(const AudioFrequency&
 template<>
 AudioFrequency IniPropertyConverter<AudioFrequency>::FromIniFile(const IniFile& iniFile, const NameString& section, const NameString& keyName, const AudioFrequency& default_value, const int index)
 {
-	return FromString(iniFile.GetValue(section, keyName, index, ToString(default_value)));
+	return FromString(iniFile.GetValue(section, keyName, ToString(default_value), index));
 }

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -320,7 +320,7 @@ std::string PackageManager::GetIniValue(NameString iniName, const NameString& se
 		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
 	}
 
-	return ini->GetValue(sectionName, keyName, index, default_value);
+	return ini->GetValue(sectionName, keyName, default_value, index);
 }
 
 std::vector<std::string> PackageManager::GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, std::vector<std::string> default_values)

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -281,7 +281,7 @@ std::unique_ptr<IniFile> PackageManager::GetIniFile(NameString iniName)
 	return std::make_unique<IniFile>(*iniFiles[iniName]);
 }
 
-std::vector<NameString> PackageManager::GetIniKeysFromSection(NameString iniName, const NameString& sectionName)
+std::unique_ptr<IniFile>& PackageManager::GetSystemIniFile(NameString iniName)
 {
 	if (iniName == "system" || iniName == "System")
 		iniName = launchInfo.gameExecutableName;
@@ -291,74 +291,35 @@ std::vector<NameString> PackageManager::GetIniKeysFromSection(NameString iniName
 	auto& ini = iniFiles[iniName];
 	if (!ini)
 	{
-		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
+		return std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
 	}
 
-	return ini->GetKeys(sectionName);
+	return ini;
+}
+
+std::vector<NameString> PackageManager::GetIniKeysFromSection(NameString iniName, const NameString& sectionName)
+{
+	return GetSystemIniFile(iniName)->GetKeys(sectionName);
 }
 
 std::string PackageManager::GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, std::string default_value, const int index)
 {
-	if (iniName == "system" || iniName == "System")
-		iniName = launchInfo.gameExecutableName;
-	else if (iniName == "user")
-		iniName = "User";
-
-	auto& ini = iniFiles[iniName];
-	if (!ini)
-	{
-		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
-	}
-
-	return ini->GetValue(sectionName, keyName, default_value, index);
+	return GetSystemIniFile(iniName)->GetValue(sectionName, keyName, default_value, index);
 }
 
 std::vector<std::string> PackageManager::GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, std::vector<std::string> default_values)
 {
-	if (iniName == "system" || iniName == "System")
-		iniName = launchInfo.gameExecutableName;
-	else if (iniName == "user")
-		iniName = "User";
-
-	auto& ini = iniFiles[iniName];
-	if (!ini)
-	{
-		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
-	}
-
-	return ini->GetValues(sectionName, keyName, default_values);
+	return GetSystemIniFile(iniName)->GetValues(sectionName, keyName, default_values);
 }
 
 void PackageManager::SetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::string& newValue, const int index)
 {
-	if (iniName == "System" || iniName == "system")
-		iniName = launchInfo.gameExecutableName;
-	else if (iniName == "user")
-		iniName = "User";
-
-	auto& ini = iniFiles[iniName];
-	if (!ini)
-	{
-		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
-	}
-
-	ini->SetValue(sectionName, keyName, newValue, index);
+	GetSystemIniFile(iniName)->SetValue(sectionName, keyName, newValue, index);
 }
 
 void PackageManager::SetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::vector<std::string>& newValues)
 {
-	if (iniName == "System" || iniName == "system")
-		iniName = launchInfo.gameExecutableName;
-	else if (iniName == "user")
-		iniName = "User";
-
-	auto& ini = iniFiles[iniName];
-	if (!ini)
-	{
-		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
-	}
-
-	ini->SetValues(sectionName, keyName, newValues);
+	GetSystemIniFile(iniName)->SetValues(sectionName, keyName, newValues);
 }
 
 void PackageManager::SaveAllIniFiles()

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -291,7 +291,7 @@ std::unique_ptr<IniFile>& PackageManager::GetSystemIniFile(NameString iniName)
 	auto& ini = iniFiles[iniName];
 	if (!ini)
 	{
-		return std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
+		ini = std::make_unique<IniFile>(FilePath::combine(launchInfo.gameRootFolder, "System/" + iniName.ToString() + ".ini"));
 	}
 
 	return ini;

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -48,9 +48,9 @@ public:
 
 	std::unique_ptr<IniFile> GetIniFile(NameString iniName);
 	std::vector<NameString> GetIniKeysFromSection(NameString iniName, const NameString& sectionName);
-	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const int index = 0, std::string default_value = "");
+	std::string GetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, std::string default_value = "", const int index = 0);
 	std::vector<std::string> GetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, std::vector<std::string> default_values = {});
-	void SetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::string& newValue);
+	void SetIniValue(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::string& newValue, const int index = 0);
 	void SetIniValues(NameString iniName, const NameString& sectionName, const NameString& keyName, const std::vector<std::string>& newValues);
 	void SaveAllIniFiles();
 

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -62,6 +62,7 @@ public:
 	bool MissingSESystemIni() const { return missing_se_system_ini; }
 
 private:
+	std::unique_ptr<IniFile>& GetSystemIniFile(NameString iniName);
 	void LoadEngineIniFiles();
 	void LoadIntFiles();
 	void LoadPackageRemaps();

--- a/Thirdparty/MurmurHash3/MurmurHash3.cpp
+++ b/Thirdparty/MurmurHash3/MurmurHash3.cpp
@@ -1,0 +1,335 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "MurmurHash3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE	__forceinline
+
+#include <stdlib.h>
+
+#define ROTL32(x,y)	_rotl(x,y)
+#define ROTL64(x,y)	_rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#define	FORCE_INLINE inline __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, int len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, const int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(int i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+

--- a/Thirdparty/MurmurHash3/MurmurHash3.h
+++ b/Thirdparty/MurmurHash3/MurmurHash3.h
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_


### PR DESCRIPTION
- Implement IniSection and IniKey instead of using nested std::map/std::vector/etc in IniFile
    - This preserves the order of ini files
    - Utilizing MurmurHash3 for quick lookup of sections/keys
- Remove package remap logic in PackageManager::GetPackage
    - Previously, package remap logic never occurred, When it does, UnrealShare never gets loaded