### PR TITLE
ChildActorsIterator update and BasedActorsIterator implementation

### DIFF
--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -238,12 +238,41 @@ void UActor::UpdateActorZone()
 void UActor::SetOwner(UActor* newOwner)
 {
 	if (Owner())
+	{
 		CallEvent(Owner(), EventName::LostChild, { ExpressionValue::ObjectValue(this) });
-
+		Owner()->RemoveChildActor(this);
+	}
+		
 	Owner() = newOwner;
 
 	if (Owner())
+	{
 		CallEvent(Owner(), EventName::GainedChild, { ExpressionValue::ObjectValue(this) });
+		Owner()->AddChildActor(this);
+	}
+}
+
+void UActor::AddChildActor(UActor* actor)
+{
+	ChildActors.push_back(actor);
+}
+
+void UActor::RemoveChildActor(UActor* actor)
+{
+	if (!actor)
+		return;
+
+	auto it = ChildActors.begin();
+
+	while (it != ChildActors.end())
+	{
+		if (*it == actor)
+		{
+			ChildActors.erase(it);
+			return;
+		}
+		it++;
+	}
 }
 
 void UActor::SetBase(UActor* newBase, bool sendBaseChangeEvent)

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -267,6 +267,12 @@ public:
 	float SleepTimeLeft = 0.0f;
 	vec3 gravityVector;
 
+	// Child actor tracking
+	std::vector<UActor*> ChildActors;
+
+	void AddChildActor(UActor* actor);
+	void RemoveChildActor(UActor* actor);
+
 	void SetTweenFromAnimFrame();
 
 	UTexture* GetMultiskin(int index)

--- a/SurrealEngine/VM/Iterator.cpp
+++ b/SurrealEngine/VM/Iterator.cpp
@@ -30,21 +30,33 @@ bool AllObjectsIterator::Next()
 
 BasedActorsIterator::BasedActorsIterator(UActor* Caller, UObject* BaseClass, UObject** Actor) : BaseClass(BaseClass), Actor(Actor)
 {
-	engine->LogUnimplemented("Actor.BasedActors");
+	for (UActor* levelActor : engine->Level->Actors)
+	{
+		if (levelActor->IsA(BaseClass->Name) && levelActor->IsBasedOn(Caller))
+			BasedActors.push_back(levelActor);
+	}
+
+	iterator = BasedActors.begin();
 }
 
 bool BasedActorsIterator::Next()
 {
-	return false;
+	if (iterator == BasedActors.end())
+		return false;
+
+	*Actor = *iterator;
+	iterator++;
+
+	return *Actor;
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
 ChildActorsIterator::ChildActorsIterator(UActor* Caller, UObject* BaseClass, UObject** Actor) : BaseClass(BaseClass), Actor(Actor)
 {
-	for (UActor* levelActor : engine->Level->Actors)
+	for (UActor* levelActor : Caller->ChildActors)
 	{
-		if (levelActor->Owner() == Caller && levelActor->IsA(BaseClass->Name))
+		if (levelActor->IsA(BaseClass->Name))
 			ChildActors.push_back(levelActor);
 	}
 

--- a/SurrealEngine/VM/Iterator.h
+++ b/SurrealEngine/VM/Iterator.h
@@ -37,6 +37,9 @@ public:
 	UObject* BaseClass = nullptr;
 	UObject** Actor = nullptr;
 	size_t index = 0;
+
+	std::vector<UActor*> BasedActors;
+	std::vector<UActor*>::iterator iterator;
 };
 
 // An Iterator for iterating through all child actors of a given actor (e.g. due to being spawned by them)


### PR DESCRIPTION
* UActors can keep track of their child actors using a simple list. ChildActorsIterator now uses this list to iterate on the relevant actors instead
* BasedActorsIterator is also implemented now