### PR TITLE
AllFiles iterator implementation and some small fixes

### DIFF
--- a/SurrealEngine/Native/NActor.cpp
+++ b/SurrealEngine/Native/NActor.cpp
@@ -202,7 +202,12 @@ void NActor::GetMapName(UObject* Self, const std::string& NameEnding, const std:
 	// Filter list to only those with the matching map type
 	for (const std::string& name : engine->packages->GetMaps())
 	{
-		if (name.size() >= NameEnding.size() && name.substr(0, NameEnding.size()) == NameEnding)
+		// Case insensitive prefix comparison because Unreal Deathmatch maps start with "Dm" instead of "DM"
+#ifdef WIN32
+		if (name.size() >= NameEnding.size() && _stricmp(name.substr(0, NameEnding.size()).c_str(), NameEnding.c_str()) == 0)
+#else
+		if (name.size() >= NameEnding.size() && strcasecmp(name.substr(0, NameEnding.size()).c_str(), NameEnding.c_str()) == 0)
+#endif
 			maps.push_back(name);
 	}
 

--- a/SurrealEngine/Native/NObject.cpp
+++ b/SurrealEngine/Native/NObject.cpp
@@ -171,6 +171,12 @@ void NObject::RegisterFunctions()
 	RegisterVMNativeFunc_3("Object", "XorXor_BoolBool", &NObject::XorXor_BoolBool, 131);
 	RegisterVMNativeFunc_3("Object", "Xor_IntInt", &NObject::Xor_IntInt, 157);
 
+	// Unreal Gold 227 exclusive functions
+	if (engine->LaunchInfo.gameExecutableName == "Unreal" && engine->LaunchInfo.engineVersion == 227)
+	{
+		RegisterVMNativeFunc_3("Object", "AllFiles", &NObject::AllFiles, 603);
+	}
+
 	// Package 61 stuff
 	if (engine->LaunchInfo.engineVersion <= 219)
 	{
@@ -274,6 +280,11 @@ void NObject::AndAnd_BoolBool(bool A, BitfieldBool* B, BitfieldBool& ReturnValue
 void NObject::And_IntInt(int A, int B, int& ReturnValue)
 {
 	ReturnValue = A & B;
+}
+
+void NObject::AllFiles(const std::string& FileExtension, const std::string& FilePrefix, std::string& outFileName)
+{
+	Frame::CreatedIterator = std::make_unique<AllFilesIterator>(FileExtension, FilePrefix, outFileName);
 }
 
 void NObject::Asc(const std::string& S, int& ReturnValue)

--- a/SurrealEngine/Native/NObject.h
+++ b/SurrealEngine/Native/NObject.h
@@ -21,6 +21,7 @@ public:
 	static void Add_IntInt(int A, int B, int& ReturnValue);
 	static void Add_RotatorRotator(const Rotator& A, const Rotator& B, Rotator& ReturnValue);
 	static void Add_VectorVector(const vec3& A, const vec3& B, vec3& ReturnValue);
+	static void AllFiles(const std::string& FileExtension, const std::string& FilePrefix, std::string& outFileName);
 	static void AndAnd_BoolBool(bool A, BitfieldBool* B, BitfieldBool& ReturnValue);
 	static void And_IntInt(int A, int B, int& ReturnValue);
 	static void Asc(const std::string& S, int& ReturnValue);

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -22,12 +22,12 @@ class PackageManager
 public:
 	PackageManager(const GameLaunchInfo& launchInfo);
 
-	bool IsUnreal1() const { return launchInfo.gameName == "Unreal"; }
+	bool IsUnreal1() const { return launchInfo.gameExecutableName == "Unreal"; }
 	bool IsUnreal1_226() const { return IsUnreal1() && launchInfo.engineVersion == 226; }
 	bool IsUnreal1_227() const { return IsUnreal1() && launchInfo.engineVersion == 227; }
-	bool IsUnrealTournament() const { return launchInfo.gameName == "UnrealTournament"; }
+	bool IsUnrealTournament() const { return launchInfo.gameExecutableName == "UnrealTournament"; }
 	bool IsUnrealTournament_469() const { return IsUnrealTournament() && launchInfo.engineVersion == 469; }
-	bool IsDeusEx() const { return launchInfo.gameName == "DeusEx"; }
+	bool IsDeusEx() const { return launchInfo.gameExecutableName == "DeusEx"; }
 
 	int GetEngineVersion() const { return launchInfo.engineVersion; }
 	int GetEngineSubVersion() const { return launchInfo.engineSubVersion; }

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -254,7 +254,8 @@ void UActor::SetOwner(UActor* newOwner)
 
 void UActor::AddChildActor(UActor* actor)
 {
-	ChildActors.push_back(actor);
+	if (actor)
+		ChildActors.push_back(actor);
 }
 
 void UActor::RemoveChildActor(UActor* actor)

--- a/SurrealEngine/VM/Iterator.cpp
+++ b/SurrealEngine/VM/Iterator.cpp
@@ -1,7 +1,9 @@
 
 #include "Precomp.h"
 #include "Iterator.h"
+#include "File.h"
 #include "Engine.h"
+#include "Package/PackageManager.h"
 #include "UObject/ULevel.h"
 #include "UObject/UActor.h"
 #include "Collision/OverlapCylinderLevel.h"
@@ -24,6 +26,37 @@ bool AllObjectsIterator::Next()
 		}
 	}
 	return false;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+AllFilesIterator::AllFilesIterator(const std::string& FileExtension, const std::string& FilePrefix, std::string& FileName) : FileExtension(FileExtension), FilePrefix(FilePrefix), FileName(FileName)
+{
+	auto packageNames = engine->packages->GetPackageNames();
+
+	for (auto& packageName : packageNames)
+	{
+		auto package = engine->packages->GetPackage(packageName);
+
+		if ((FileExtension.empty() || FilePath::extension(package->GetPackageFilename()) == FileExtension) && 
+			(FilePrefix.empty() || package->GetPackageFilename().find(FilePrefix) != std::string::npos))
+		{
+			FoundFiles.push_back(packageName.ToString());
+		}
+	}
+
+	iterator = FoundFiles.begin();
+}
+
+bool AllFilesIterator::Next()
+{
+	if (iterator == FoundFiles.end())
+		return false;
+
+	FileName = *iterator;
+	iterator++;
+
+	return true;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/VM/Iterator.h
+++ b/SurrealEngine/VM/Iterator.h
@@ -28,6 +28,22 @@ private:
 	size_t index = 0;
 };
 
+// As seen on Unreal Gold 227
+class AllFilesIterator : public Iterator
+{
+public:
+	// Iterates through all files of a type (Extensions are the usual Unreal Package extensions, or all files, if the FileExtension string is empty)
+	AllFilesIterator(const std::string& FileExtension, const std::string& FilePrefix, std::string& FileName);
+	bool Next() override;
+
+private:
+	std::string FileExtension;
+	std::string FilePrefix;
+	std::string& FileName;
+	std::vector<std::string> FoundFiles;
+	std::vector<std::string>::iterator iterator;
+};
+
 class BasedActorsIterator : public Iterator
 {
 public:


### PR DESCRIPTION
* IsGame checks were rather broken ever since the GameLaunchInfo changes, because gameName field is now about the game's name, instead of executable. Fixed this one.
* `UActor::AddChildActor()` should had a nullptr check for the actor being added. Fixed this too.
* Implemented iterator function `AllFiles()`, which seems to be present only in Unreal 227
* GetMapName() now checks prefixes in a case insensitive manner. This fixes map filtering in Unreal Gold (the maps listed in Botmatch menu); as the maps are named like "DmAriza" instead of "DM-Ariza" like they'd in Unreal Tournament, yet the prefix to check was always "DM".