### PR TITLE
Non-destructive ini file editing

### DIFF
--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -22,6 +22,7 @@ extern const char* __progname;
 #endif
 #include <stdexcept>
 #include <string.h>
+#include <sstream>
 
 #ifdef WIN32
 
@@ -218,6 +219,25 @@ std::string File::read_all_text(const std::string& filename)
 	buffer.resize(size);
 	file->read(&buffer[0], buffer.size());
 	return buffer;
+}
+
+std::vector<std::string> File::read_all_lines(const std::string& filename)
+{
+	std::string text = read_all_text(filename);
+
+	if (text.empty())
+		return {};
+
+	std::vector<std::string> result;
+
+	std::string buffer;
+
+	std::stringstream ss(text);
+
+	while (std::getline(ss, buffer)) // Default delimiter is '\n'
+		result.push_back(buffer);
+
+	return result;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/File.h
+++ b/SurrealEngine/File.h
@@ -33,6 +33,7 @@ public:
 	static void write_all_text(const std::string& filename, const std::string& text);
 	static std::vector<uint8_t> read_all_bytes(const std::string& filename);
 	static std::string read_all_text(const std::string& filename);
+	static std::vector<std::string> read_all_lines(const std::string& filename);
 
 	uint8_t read_uint8() { uint8_t v; read(&v, sizeof(uint8_t)); return v; }
 	int8_t read_int8() { int8_t v; read(&v, sizeof(int8_t)); return v; }

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -295,7 +295,7 @@ void IniFile::UpdateFile()
 				}
 
 				// If the key don't have any brackets, check if we encountered the said key before
-					// If we did, then get the next index from it, else add the key we found to the database
+				// If we did, then get the next index from it, else add the key we found to the database
 				int found_index = 0;
 				bool occurance_found = false;
 

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -200,9 +200,17 @@ void IniFile::SaveTo(const std::string& filename)
 
 void IniFile::UpdateFile()
 {
+	UpdateFile(ini_file_path);
+}
+
+void IniFile::UpdateFile(const std::string& filename)
+{
+	if (filename == ini_file_path && !isModified)
+		return;
+
 	// The logic is simple: Read the file, check each line one-by-one, modify the differing lines, and write everything back
 	// The implementation however, is not :V
-	auto lines = File::read_all_lines(ini_file_path);
+	auto lines = File::read_all_lines(filename);
 
 	const IniSection* current_section = nullptr;
 
@@ -341,9 +349,20 @@ void IniFile::UpdateFile()
 			final_text += "\n";
 	}
 	
-	File::write_all_text(ini_file_path, final_text);
+	File::write_all_text(filename, final_text);
+
+	if (filename != ini_file_path)
+		ini_file_path = filename;
 
 	isModified = false;
+}
+
+void IniFile::UpdateIfExists(const std::string& filename)
+{
+	if (File::try_open_existing(filename))
+		UpdateFile(filename);
+	else
+		SaveTo(filename);
 }
 
 IniSection& IniFile::AddUniqueSection(const std::string& sectionName)

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -198,6 +198,152 @@ void IniFile::SaveTo(const std::string& filename)
 	isModified = false;
 }
 
+void IniFile::UpdateFile()
+{
+	// The logic is simple: Read the file, check each line one-by-one, modify the differing lines, and write everything back
+	// The implementation however, is not :V
+	auto lines = File::read_all_lines(ini_file_path);
+
+	const IniSection* current_section = nullptr;
+
+	// A key can contain multiple values, so we gotta compare if we're getting the same key again and again
+	struct KeyOccurance
+	{
+		std::string keyName = "";
+		unsigned int currentIndex = 0;
+	};
+
+	std::vector<KeyOccurance> keyOccurrances;
+
+	bool key_has_brackets = false;
+	std::string ini_value;			// Value read from the ini file
+
+	for (auto line_it = lines.begin() ; line_it != lines.end() ; line_it++)
+	{
+		std::string line = *line_it;
+
+		if (line.empty() || line[0] == ';')
+			// Do nothing on empty line
+			continue;
+
+		if (line.front() == '[' && line.back() == ']')
+		{
+			// If we're switching from a different section, check for values not in the file, but in the memory, and add them
+			if (current_section)
+			{
+				auto& section_keys = current_section->GetKeys();
+
+				for (auto& key : section_keys)
+				{
+					bool key_found = false;
+					for (auto& keyOccurrance : keyOccurrances)
+					{
+						if (key.GetName() == keyOccurrance.keyName)
+						{
+							key_found = true;
+							break;
+						}
+					}
+
+					if (key_found)
+						continue;
+
+					auto& values = key.GetValues();
+
+					for (auto& value : values)
+					{
+						std::string newline = key.GetName() + "=" + value;
+
+						line_it = lines.insert(line_it - 2, newline);
+
+						line_it += 2;
+					}
+				}
+			}
+
+			// Switch sections
+			std::string new_section_name = line.substr(1, line.length() - 2);
+
+			current_section = FindSection(new_section_name);
+
+			keyOccurrances.clear();
+
+			continue;
+		}
+
+		// Check stuff out only if we're in a relevant section
+		if (current_section)
+		{
+			size_t equal_pos = line.find('=');
+
+			if (equal_pos != std::string::npos)
+			{
+				std::string key = line.substr(0, equal_pos);
+				std::string key_without_brackets = key; // Will differ from key if the said key contains brackets
+				std::string value = line.substr(equal_pos + 1);
+
+				size_t left_bracket_pos = key.find('['),
+					   right_bracket_pos = key.find(']');
+
+				int bracket_index = 0;
+
+				if (left_bracket_pos != std::string::npos && right_bracket_pos != std::string::npos && left_bracket_pos < right_bracket_pos)
+				{
+					bracket_index = std::stoi(key.substr(left_bracket_pos, right_bracket_pos - left_bracket_pos + 1));
+					key_without_brackets = key.substr(0, left_bracket_pos);
+					key_has_brackets = true;
+				}
+
+				// If the key don't have any brackets, check if we encountered the said key before
+					// If we did, then get the next index from it, else add the key we found to the database
+				int found_index = 0;
+				bool occurance_found = false;
+
+				for (auto& keyOccurrance : keyOccurrances)
+				{
+					if (keyOccurrance.keyName == key_without_brackets)
+					{
+						keyOccurrance.currentIndex++;
+						occurance_found = true;
+						break;
+					}
+
+					found_index++;
+				}
+
+				if (!occurance_found)
+				{
+					// Must be a new occurrance
+					keyOccurrances.push_back({ key, 0 });
+				}
+
+				// Read and compare the value of the current line
+				if (key_has_brackets)
+					ini_value = current_section->GetValue(key_without_brackets, "", bracket_index);
+				else
+					ini_value = current_section->GetValue(key, "", occurance_found ? keyOccurrances[found_index].currentIndex : 0);
+				
+				// Update the current line if the value differs
+				if (value != ini_value)
+					*line_it = key + "=" + value;
+			}
+		}
+	}
+
+	// Combine lines back
+	std::string final_text = "";
+
+	for (auto& line : lines)
+	{
+		final_text += line;
+
+		if (line != "\n")
+			final_text += "\n";
+	}
+	
+	File::write_all_text(ini_file_path, final_text);
+}
+
 IniSection& IniFile::AddUniqueSection(const std::string& sectionName)
 {
 	uint32_t sectionHash = HashIniString(sectionName);

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -342,6 +342,8 @@ void IniFile::UpdateFile()
 	}
 	
 	File::write_all_text(ini_file_path, final_text);
+
+	isModified = false;
 }
 
 IniSection& IniFile::AddUniqueSection(const std::string& sectionName)

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -73,6 +73,10 @@ public:
 	// Saves values to a specified file
 	void SaveTo(const std::string& filename);
 
+	// Compares the text written in the ini file with what's in the memory, and updates the changed sections
+	// (File is still completely replaced, but this way the previous additional data in it won't be lost)
+	void UpdateFile();
+
 private:
 	bool ReadLine(const std::string& text, size_t& pos, std::string& line);
 

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -76,6 +76,11 @@ public:
 	// Compares the text written in the ini file with what's in the memory, and updates the changed sections
 	// (File is still completely replaced, but this way the previous additional data in it won't be lost)
 	void UpdateFile();
+	// Updates values in a specified file
+	void UpdateFile(const std::string& filename);
+
+	// Updates the file with the changed values if it exists, otherwise saves the values to a new file instead
+	void UpdateIfExists(const std::string& filename);
 
 private:
 	bool ReadLine(const std::string& text, size_t& pos, std::string& line);

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -333,12 +333,12 @@ void PackageManager::SaveAllIniFiles()
 		if (iniFile.first == launchInfo.gameExecutableName)
 		{
 			const std::string engine_ini_name = "SE-" + launchInfo.gameExecutableName + ".ini";
-			iniFile.second->SaveTo(FilePath::combine(system_folder, engine_ini_name));
+			iniFile.second->UpdateIfExists(FilePath::combine(system_folder, engine_ini_name));
 		}
 		else if (iniFile.first == "User")
-			iniFile.second->SaveTo(FilePath::combine(system_folder, "SE-User.ini"));
+			iniFile.second->UpdateIfExists(FilePath::combine(system_folder, "SE-User.ini"));
 		else
-			iniFile.second->SaveTo();
+			iniFile.second->UpdateFile();
 	}
 }
 

--- a/SurrealEngine/UObject/UClass.cpp
+++ b/SurrealEngine/UObject/UClass.cpp
@@ -625,3 +625,20 @@ UProperty* UClass::GetProperty(const NameString& propName)
 	}
 	throw std::runtime_error("Class Property '" + Name.ToString() + "." + propName.ToString() + "' not found");
 }
+
+void UClass::SaveToConfig(PackageManager& packageManager)
+{
+	if (!(ClsFlags & ClassFlags::Config))
+		return;
+
+	auto ini_file = packageManager.GetIniFile(ClassConfigName);
+
+	// Iterate and save Properties that are marked with Config
+	for (UProperty* prop : PropertyData.Class->Properties)
+	{
+		if ((uint32_t)(prop->PropFlags & PropertyFlags::Config))
+		{
+			ini_file->SetValue(this->Name, prop->Name, prop->PrintValue(PropertyData.Ptr(prop)));
+		}
+	}
+}

--- a/SurrealEngine/UObject/UClass.h
+++ b/SurrealEngine/UObject/UClass.h
@@ -183,6 +183,8 @@ public:
 	UProperty* GetProperty(const NameString& name);
 	UObject* GetDefaultObject() { return this; }
 
+	void SaveToConfig(PackageManager& packageManager);
+
 	uint32_t OldClassRecordSize = 0;
 	ClassFlags ClsFlags = {};
 	Guid ClassGuid;


### PR DESCRIPTION
This PR adds some new functions to help with saving the ini files in a non-destructive manner, aka only updating the changed sections.

Implementing SaveConfig() will be done at a later PR, as while it should be easy to do so after these changes, I don't want to deal with any sort of file conflicts atm.