### PR TITLE
Implement SaveConfig()

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -191,9 +191,6 @@ void Engine::Run()
 
 	window->UnlockCursor();
 
-	client->SaveProperties();
-	audiodev->SaveProperties();
-	renderdev->SaveProperties();
 	packages->SaveAllIniFiles();
 
 	CloseWindow();

--- a/SurrealEngine/Native/NObject.cpp
+++ b/SurrealEngine/Native/NObject.cpp
@@ -902,7 +902,8 @@ void NObject::RotRand(BitfieldBool* bRoll, Rotator& ReturnValue)
 
 void NObject::SaveConfig(UObject* Self)
 {
-	engine->LogUnimplemented("Object.SaveConfig(name=" + Self->Name.ToString() + ", class=" + UObject::GetUClassName(Self).ToString() + ")");
+	//engine->LogUnimplemented("Object.SaveConfig(name=" + Self->Name.ToString() + ", class=" + UObject::GetUClassName(Self).ToString() + ")");
+	Self->SaveConfig();
 }
 
 void NObject::SetPropertyText(UObject* Self, const std::string& PropName, const std::string& PropValue)

--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -288,7 +288,7 @@ void IniFile::UpdateFile(const std::string& filename)
 			{
 				std::string key = line.substr(0, equal_pos);
 				std::string key_without_brackets = key; // Will differ from key if the said key contains brackets
-				std::string value = line.substr(equal_pos + 1);
+				std::string value_from_file = line.substr(equal_pos + 1);
 
 				size_t left_bracket_pos = key.find('['),
 					   right_bracket_pos = key.find(']');
@@ -332,8 +332,8 @@ void IniFile::UpdateFile(const std::string& filename)
 					ini_value = current_section->GetValue(key, "", occurance_found ? keyOccurrances[found_index].currentIndex : 0);
 				
 				// Update the current line if the value differs
-				if (value != ini_value)
-					*line_it = key + "=" + value;
+				if (value_from_file != ini_value)
+					*line_it = key + "=" + ini_value;
 			}
 		}
 	}

--- a/SurrealEngine/UObject/UObject.cpp
+++ b/SurrealEngine/UObject/UObject.cpp
@@ -132,6 +132,11 @@ void UObject::SetPropertyFromString(const NameString& name, const std::string& v
 	throw std::runtime_error("UObject::SetPropertyFromString not implemented");
 }
 
+void UObject::SaveConfig()
+{
+	Class->SaveToConfig(*engine->packages.get());
+}
+
 uint8_t UObject::GetByte(const NameString& name) const
 {
 	return *static_cast<const uint8_t*>(GetProperty(name));

--- a/SurrealEngine/UObject/UObject.h
+++ b/SurrealEngine/UObject/UObject.h
@@ -177,6 +177,8 @@ public:
 	virtual std::string GetPropertyAsString(const NameString& name) const;
 	virtual void SetPropertyFromString(const NameString& name, const std::string& value);
 
+	virtual void SaveConfig();
+
 	uint8_t GetByte(const NameString& name) const;
 	uint32_t GetInt(const NameString& name) const;
 	bool GetBool(const NameString& name) const;

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -55,7 +55,7 @@ void USurrealRenderDevice::LoadProperties(const NameString& from)
 	HighDetailActors = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "HighDetailActors", HighDetailActors);
 }
 
-void USurrealRenderDevice::SaveProperties()
+void USurrealRenderDevice::SaveConfig()
 {
 	engine->packages->SetIniValue("System", Class, "Translucency", IniPropertyConverter<bool>::ToString(Translucency));
 	engine->packages->SetIniValue("System", Class, "VolumetricLighting", IniPropertyConverter<bool>::ToString(VolumetricLighting));
@@ -172,7 +172,7 @@ void USurrealAudioDevice::LoadProperties(const NameString& from)
 	AmbientFactor = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "AmbientFactor", AmbientFactor);
 }
 
-void USurrealAudioDevice::SaveProperties()
+void USurrealAudioDevice::SaveConfig()
 {
 	engine->packages->SetIniValue("System", Class, "UseFilter", IniPropertyConverter<bool>::ToString(UseFilter));
 	engine->packages->SetIniValue("System", Class, "UseSurround", IniPropertyConverter<bool>::ToString(UseSurround));
@@ -235,7 +235,7 @@ void USurrealClient::LoadProperties(const NameString& from)
 	SkinDetail = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("System"), name_from, "SkinDetail", SkinDetail);
 }
 
-void USurrealClient::SaveProperties()
+void USurrealClient::SaveConfig()
 {
 	engine->packages->SetIniValue("System", Class, "StartupFullscreen", IniPropertyConverter<bool>::ToString(StartupFullscreen));
 	engine->packages->SetIniValue("System", Class, "WindowedViewportX", IniPropertyConverter<int>::ToString(WindowedViewportX));

--- a/SurrealEngine/UObject/USubsystem.h
+++ b/SurrealEngine/UObject/USubsystem.h
@@ -11,7 +11,6 @@ public:
 	using UObject::UObject;
 
 	virtual void LoadProperties(const NameString& from = "") {}
-	virtual void SaveProperties() {}
 };
 
 class ULanguage : public UObject
@@ -77,7 +76,7 @@ public:
 	bool HighDetailActors = true;
 
 	void LoadProperties(const NameString& from = "") override;
-	void SaveProperties() override;
+	void SaveConfig() override;
 
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;
@@ -107,7 +106,7 @@ public:
 	float AmbientFactor = 0.7f;
 
 	void LoadProperties(const NameString& from = "") override;
-	void SaveProperties() override;
+	void SaveConfig() override;
 
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;
@@ -147,7 +146,7 @@ public:
 	std::string SkinDetail = "High";
 
 	void LoadProperties(const NameString& from = "");
-	void SaveProperties();
+	void SaveConfig() override;
 
 	std::string GetPropertyAsString(const NameString& propertyName) const override;
 	void SetPropertyFromString(const NameString& propertyName, const std::string& value) override;


### PR DESCRIPTION
Now all classes that has the config attribute will be able to save their stuff to the ini files. With this, we can remove the code that saves all subsystems' configurations before the engine shuts down, as SaveConfig() will take care of those.

Also UpdateFile() was a bit broken, as we were writing the value that was already in the file back there. This PR fixes that.