### PR TITLE
Stop items from rotating once they land

### DIFF
--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -828,6 +828,8 @@ void UActor::TickProjectile(float elapsed)
 		return;
 	}
 
+	ApplyRotationPhysics(*this, elapsed);
+
 	UZoneInfo* zone = Region().Zone;
 	UProjectile* projectile = UObject::TryCast<UProjectile>(this);
 	UPawn* pawn = UObject::TryCast<UPawn>(this);


### PR DESCRIPTION
Rotation physics are applied to falling and rotating objects only. This means that grenades will no longer keep rotating once they land.

This also removes the need for the rotating pickup check. (I guess rotating items get their physics set to "rotating", and others get it set to "none").

Visual Studio also autoformatted some other parts of the file. Hope it's not an issue.