### PR TITLE
Level transition fixes

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -158,7 +158,7 @@ void Engine::Run()
 		{
 			// To do: need to do something about that travel type and transfering of items
 
-			UnrealURL url(LevelInfo->URL, ClientTravelInfo.URL.ToString());
+			UnrealURL url(LevelInfo->URL, ClientTravelInfo.URL);
 			LogMessage("Client travel to " + url.ToString());
 			LoadMap(url);
 			LoginPlayer();

--- a/SurrealEngine/UObject/UnrealURL.cpp
+++ b/SurrealEngine/UObject/UnrealURL.cpp
@@ -47,17 +47,18 @@ UnrealURL::UnrealURL(const std::string& urlString)
 	if (teleportTagPos != std::string::npos)
 	{
 		mapName = urlString.substr(0, teleportTagPos);
+		std::string allOptsString = urlString.substr(teleportTagPos + 1);
 
-		size_t optionsTagPos = urlString.find_first_of('?');
+		size_t optionsTagPos = allOptsString.find_first_of('?');
 
 		if (optionsTagPos != std::string::npos)
 		{
-			teleportTag = urlString.substr(teleportTagPos + 1, optionsTagPos - teleportTagPos + 1);
-			options = urlString.substr(optionsTagPos + 1);
+			teleportTag = allOptsString.substr(0, optionsTagPos);
+			options = allOptsString.substr(optionsTagPos + 1);
 		}
 		else
 			// No options mean that the string consists of only the map name and teleporter tag
-			teleportTag = urlString.substr(teleportTagPos + 1);
+			teleportTag = allOptsString;
 	}
 	else
 	{

--- a/SurrealEngine/UObject/UnrealURL.cpp
+++ b/SurrealEngine/UObject/UnrealURL.cpp
@@ -2,31 +2,18 @@
 
 #include <sstream>
 
-UnrealURL::UnrealURL(const UnrealURL& base, const std::string& url)
+UnrealURL::UnrealURL(const UnrealURL& baseURL, const UnrealURL& nextURL)
 {
 	// To do: this also needs to be able to handle fully qualified URLs for network support
 
-	*this = base;
+	*this = baseURL;
 
-	size_t pos = url.find('?');
-	if (pos == std::string::npos)
-	{
-		Map = url;
-	}
-	else
-	{
-		Map = url.substr(0, pos);
+	// Pass options from the nextURL to the base one
+	Map = nextURL.Map;
+	Portal = nextURL.Portal;
 
-		pos++;
-		while (pos < url.size())
-		{
-			size_t endpos = url.find('?', pos);
-			if (endpos == std::string::npos)
-				endpos = url.size();
-			AddOrReplaceOption(url.substr(pos, endpos - pos));
-			pos = endpos + 1;
-		}
-	}
+	for (auto& option : nextURL.Options)
+		AddOrReplaceOption(option);
 
 	// Unreal uses relative urls
 	if (Map.size() > 8 && Map.substr(0, 8) == "..\\maps\\")
@@ -185,10 +172,7 @@ std::string UnrealURL::GetOptions() const
 
 std::string UnrealURL::GetPortal() const
 {
-	if (!Portal.empty())
-		return "#" + Portal;
-	else
-		return std::string();
+	return Portal;
 }
 
 std::string UnrealURL::ToString() const

--- a/SurrealEngine/UObject/UnrealURL.cpp
+++ b/SurrealEngine/UObject/UnrealURL.cpp
@@ -20,10 +20,16 @@ UnrealURL::UnrealURL(const UnrealURL& baseURL, const UnrealURL& nextURL)
 		Map = Map.substr(8);
 }
 
-UnrealURL::UnrealURL(const std::string& urlString)
+UnrealURL::UnrealURL(std::string urlString)
 {
 	// Expected url format on a local game:
 	// mapname[#teleporttag][?key1=value1[?key2=value2]...]
+
+	// Trim the url string of whitespaces
+	// Fixes the crash during the transition from Temple of Vandora to The Trench in Unreal
+	// Due to the exit teleporter pointing to " trench" (with the whitespace at the beginning)
+	urlString.erase(urlString.find_last_not_of(' ') + 1);
+	urlString.erase(0, urlString.find_first_not_of(' '));
 
 	std::string mapName = "";
 	std::string teleportTag = "";

--- a/SurrealEngine/UObject/UnrealURL.h
+++ b/SurrealEngine/UObject/UnrealURL.h
@@ -6,7 +6,9 @@ class UnrealURL
 {
 public:
 	UnrealURL() = default;
-	UnrealURL(const UnrealURL& base, const std::string& url);
+	// Constructs an UnrealURL by passing the options from nextURL to the baseURL
+	UnrealURL(const UnrealURL& baseURL, const UnrealURL& nextURL);
+	// Constructs an UnrealURL from a given parse-able string.
 	UnrealURL(const std::string& urlString);
 
 	void AddOrReplaceOption(const std::string& newvalue);

--- a/SurrealEngine/UObject/UnrealURL.h
+++ b/SurrealEngine/UObject/UnrealURL.h
@@ -9,7 +9,7 @@ public:
 	// Constructs an UnrealURL by passing the options from nextURL to the baseURL
 	UnrealURL(const UnrealURL& baseURL, const UnrealURL& nextURL);
 	// Constructs an UnrealURL from a given parse-able string.
-	UnrealURL(const std::string& urlString);
+	UnrealURL(std::string urlString);
 
 	void AddOrReplaceOption(const std::string& newvalue);
 	bool HasOption(const std::string& name) const;


### PR DESCRIPTION
With these changes:

* Transitioning levels using teleporters will work correctly (player will end up at the proper "start teleporter" of the next map) (still no inventory travel though)
* UT City Flyby no longer crashes once it reaches to the end, and now restarts properly (probably due to the same reason above)
* URL string is trimmed to prevent a crash during the level transition from Temple of Vandora to The Trench, due to the exit teleporter accidentally pointing to " trench" (with the whitespace at the beginning) as the next map