### PR TITLE
Get Unreal New Game menu working

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -286,7 +286,13 @@ void Engine::LoadMap(const UnrealURL& url, const std::map<std::string, std::stri
 	UnloadMap();
 
 	// Load map objects
-	LevelPackage = packages->GetPackage(FilePath::remove_extension(url.Map));
+
+	// Determine if we're getting a relative path
+	// Which is the case with Unreal's New game menu
+	if (url.Map.substr(0, 2) == "..")
+		LevelPackage = packages->GetPackageFromPath(url.Map);
+	else
+		LevelPackage = packages->GetPackage(FilePath::remove_extension(url.Map));
 
 	LevelInfo = UObject::Cast<ULevelInfo>(LevelPackage->GetUObject("LevelInfo", "LevelInfo0"));
 	if (packages->IsUnreal1())

--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -624,3 +624,27 @@ std::string FilePath::convert_path_delimiters(const std::string &path)
 #endif
 	return result;
 }
+
+std::string FilePath::relative_to_absolute_from_system(std::string game_system_path, std::string relative_path)
+{
+	// Get the filename
+	std::string filename = FilePath::last_component(relative_path);
+	relative_path = FilePath::remove_last_component(relative_path);
+
+	auto first_component = FilePath::first_component(relative_path);
+
+	while (first_component == ".." || first_component == ".")
+	{
+		if (first_component == "..")
+		{
+			// "Go one directory up" as many as the amount of ".."s in the current_path
+			game_system_path = FilePath::remove_last_component(game_system_path);
+		}
+
+		relative_path = FilePath::remove_first_component(relative_path);
+		first_component = FilePath::first_component(relative_path);
+	}
+
+	// Combine everything
+	return FilePath::combine(game_system_path, relative_path);
+}

--- a/SurrealEngine/File.cpp
+++ b/SurrealEngine/File.cpp
@@ -627,10 +627,6 @@ std::string FilePath::convert_path_delimiters(const std::string &path)
 
 std::string FilePath::relative_to_absolute_from_system(std::string game_system_path, std::string relative_path)
 {
-	// Get the filename
-	std::string filename = FilePath::last_component(relative_path);
-	relative_path = FilePath::remove_last_component(relative_path);
-
 	auto first_component = FilePath::first_component(relative_path);
 
 	while (first_component == ".." || first_component == ".")

--- a/SurrealEngine/File.h
+++ b/SurrealEngine/File.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <memory>
@@ -79,4 +78,6 @@ public:
 	static std::string remove_last_component(const std::string &path);
 	static std::string combine(const std::string &path1, const std::string &path2);
 	static std::string convert_path_delimiters(const std::string &path);
+	// Converts a relative path to an absolute one, starting from the system path of the current game.
+	static std::string relative_to_absolute_from_system(std::string game_system_path, std::string relative_path);
 };

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -33,6 +33,7 @@ public:
 	int GetEngineSubVersion() const { return launchInfo.engineSubVersion; }
 
 	Package *GetPackage(const NameString& name);
+	Package *GetPackageFromPath(const std::string& path);
 	std::vector<NameString> GetPackageNames() const;
 
 	void UnloadPackage(const NameString& name);

--- a/SurrealEngine/UObject/UnrealURL.cpp
+++ b/SurrealEngine/UObject/UnrealURL.cpp
@@ -15,9 +15,11 @@ UnrealURL::UnrealURL(const UnrealURL& baseURL, const UnrealURL& nextURL)
 	for (auto& option : nextURL.Options)
 		AddOrReplaceOption(option);
 
+	/*
 	// Unreal uses relative urls
 	if (Map.size() > 8 && Map.substr(0, 8) == "..\\maps\\")
 		Map = Map.substr(8);
+	*/
 }
 
 UnrealURL::UnrealURL(std::string urlString)
@@ -68,10 +70,11 @@ UnrealURL::UnrealURL(std::string urlString)
 			mapName = urlString;
 	}
 
+	/*
 	// Remove map extension from mapName if it is there
-	size_t extPos = mapName.find(".");
+	size_t extPos = mapName.find_last_of(".");
 	if (extPos != std::string::npos)
-		mapName = mapName.substr(0, extPos);
+		mapName = mapName.substr(0, extPos);*/
 
 	Map = mapName;
 	Portal = teleportTag;


### PR DESCRIPTION
Now it is possible to start both Unreal and Return to Na Pali from Unreal Gold's New Game menu.

RTNP crashes at the first playable level though.