### PR TITLE
Add detection of Tactical-Ops: Assault on Terror (3.4.0 and 3.5.0, running on UT436 and 469 engines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At the time of this writing, SurrealEngine can detect the following UE1 games:
 * NERF Arena Blast (v300)
 * TNN Outdoors Pro Hunter (v200)
 * Rune Classic (v1.10)
+* Tactical-Ops: Assault on Terror (v3.4.0 and v3.5.0 - both running under UT436 and UT469 engines)
 
 Clive Barker's Undying (v420) is also in the database, but there is no corresponding SHA1sum for its executable file yet.
 

--- a/SurrealEngine/GameFolder.cpp
+++ b/SurrealEngine/GameFolder.cpp
@@ -237,6 +237,23 @@ GameLaunchInfo GameFolderSelection::ExamineFolder(const std::string& path)
 				info.gameVersionString = "1.10";
 			}
 			break;
+			case KnownUE1Games::TACTICAL_OPS_436:
+			{
+				info.gameName = "Tactical-Ops: Assault on Terror";
+				info.engineVersion = 436;
+				info.engineSubVersion = 0;
+				info.gameVersionString = "436";
+			}
+			break;
+			case KnownUE1Games::TACTICAL_OPS_469:
+			{
+				// exe is identical to UT v469d
+				info.gameName = "Tactical-Ops: Assault on Terror";
+				info.engineVersion = 469;
+				info.engineSubVersion = 3;
+				info.gameVersionString = "469d";
+			}
+			break;
 		}
 	}
 	

--- a/SurrealEngine/UE1GameDatabase.cpp
+++ b/SurrealEngine/UE1GameDatabase.cpp
@@ -39,6 +39,10 @@ std::pair<KnownUE1Games, std::string> FindUE1GameInPath(const std::string& ue1_g
 			if (it == SHA1Database.end())
 				return std::make_pair(KnownUE1Games::UE1_GAME_NOT_FOUND, "");
 
+			// Hack: Tactical-Ops has a version that contains the exact same UTv469d executable. Handle that here
+			if (it->second == KnownUE1Games::UT99_469d && executable_name == "TacticalOps.exe")
+				return std::make_pair(KnownUE1Games::TACTICAL_OPS_469, executable_name);
+
 			return std::make_pair(it->second, executable_name);
 		}
 	}

--- a/SurrealEngine/UE1GameDatabase.h
+++ b/SurrealEngine/UE1GameDatabase.h
@@ -30,7 +30,9 @@ enum class KnownUE1Games
 	NERF_300,
 	TNN_200,
 	RUNE_110,
-	UNDYING_420
+	UNDYING_420,
+	TACTICAL_OPS_436,
+	TACTICAL_OPS_469,
 };
 
 static const std::map<std::string, KnownUE1Games> SHA1Database = {
@@ -131,7 +133,14 @@ static const std::map<std::string, KnownUE1Games> SHA1Database = {
 	{"4a517c7f96a27cf7e25534c80d50af8db4065276", KnownUE1Games::RUNE_110},
 
 	// TNN Outdoors Pro Hunter
-	{"f4fbacdaaee360794187c8224f51ea82bd902a43", KnownUE1Games::TNN_200}
+	{"f4fbacdaaee360794187c8224f51ea82bd902a43", KnownUE1Games::TNN_200},
+
+	// Tactical-Ops: Assault On Terror
+	// v3.4.0 and v3.5.0, running on UT v436 engine
+	{"3175cee69d3808b70213b171b6e0e635daefaee1", KnownUE1Games::TACTICAL_OPS_436},
+	// v3.4.0 and v3.5.0, running on UT v469 engine
+	// Has identical hash to UT v469d executable
+	// {"78c65e9434b442b15820d863136bb5a44700ad26", KnownUE1Games::TACTICAL_OPS_469},
 };
 
 static const std::vector<std::string> knownUE1ExecutableNames = {
@@ -147,7 +156,8 @@ static const std::vector<std::string> knownUE1ExecutableNames = {
 	"Nerf.exe",
 	"Rune.exe",
 	"Spore.exe",
-	"TnnHunt.exe"
+	"TnnHunt.exe",
+	"TacticalOps.exe"
 };
 
 // Returns a pair of UE1-Game type and executable name


### PR DESCRIPTION
Game launches under the 436 engine (in both versions, not sure how they differ), but attempting to open the main menu crashes the game, as well as trying to load a map with the `open` command.

Detecting 469 is a bit hack-y, as they use the exact same executable from UT 469d there.