### PR TITLE
Inventory Travel Mechanics, Pt. 2

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -168,12 +168,13 @@ void Engine::Run()
 				if (pawn && pawn->Player())
 				{
 					std::vector<ObjectTravelInfo> actorTravelInfo;
-					actorTravelInfo.push_back(ObjectTravelInfo(pawn));
 					for (UInventory* item = pawn->Inventory(); item != nullptr; item = item->Inventory())
 					{
 						ObjectTravelInfo objInfo(item);
 						actorTravelInfo.push_back(std::move(objInfo));
 					}
+					// Add the pawn itself last
+					actorTravelInfo.push_back(ObjectTravelInfo(pawn));
 					std::string playerName = pawn->PlayerReplicationInfo()->PlayerName();
 					travelInfo[playerName] = ObjectTravelInfo::ToString(actorTravelInfo);
 				}
@@ -542,6 +543,17 @@ void Engine::LoginPlayer()
 	CallEvent(LevelInfo->Game(), EventName::PostLogin, { ExpressionValue::ObjectValue(pawn) });
 
 	render->OnMapLoaded();
+}
+
+UObject* Engine::FindObject(NameString name, NameString className)
+{
+	for (auto actor : Level->Actors)
+	{
+		if (actor && actor->Name == name && UObject::GetUClassFullName(actor) == className)
+			return actor;
+	}
+
+	return nullptr;
 }
 
 float Engine::CalcTimeElapsed()

--- a/SurrealEngine/Engine.h
+++ b/SurrealEngine/Engine.h
@@ -72,6 +72,9 @@ public:
 	void LoadMap(const UnrealURL& url, const std::map<std::string, std::string>& travelInfo = {});
 	void UnloadMap();
 	void LoginPlayer();
+
+	UObject* FindObject(NameString name, NameString className);
+
 	std::string ConsoleCommand(UObject* context, const std::string& command, BitfieldBool& found);
 
 	void UpdateInput(float timeElapsed);

--- a/SurrealEngine/UObject/ObjectTravelInfo.cpp
+++ b/SurrealEngine/UObject/ObjectTravelInfo.cpp
@@ -36,6 +36,19 @@ ObjectTravelInfo::ObjectTravelInfo(UActor* travelActor)
 		for (UProperty* property : allProperties)
 			Properties[property->Name.ToString()] = travelActor->GetPropertyAsString(property->Name);
 	}
+
+	if (isPlayerPawn)
+	{
+		// Hacky workaround for selected Weapon and Inventory
+		auto playerActor = UObject::Cast<UPlayerPawn>(travelActor);
+		auto selectedInventory = UObject::Cast<UInventory>(playerActor->GetUObject("SelectedItem"));
+		if (selectedInventory)
+			Properties["SelectedItem"] = "{ name=None, class=" + UObject::GetUClassFullName(selectedInventory).ToString() + " }";
+
+		auto selectedWeapon = UObject::Cast<UInventory>(playerActor->GetUObject("Weapon"));
+		if (selectedWeapon)
+			Properties["Weapon"] = "{ name=None, class=" + UObject::GetUClassFullName(selectedWeapon).ToString() + " }";
+	}
 }
 
 std::vector<ObjectTravelInfo> ObjectTravelInfo::Parse(const std::string& text)

--- a/SurrealEngine/UObject/UObject.cpp
+++ b/SurrealEngine/UObject/UObject.cpp
@@ -132,7 +132,78 @@ void UObject::SetPropertyFromString(const NameString& name, const std::string& v
 	for (UProperty* prop : PropertyData.Class->Properties)
 	{
 		if (prop->Name == name)
-			prop->SetValueFromString(PropertyData.Ptr(prop), value);
+		{
+			switch (prop->ValueType)
+			{
+				case ExpressionValueType::Nothing:
+					throw std::runtime_error("Attempted to change a None property: " + name.ToString());
+
+				case ExpressionValueType::ValueByte:
+				{
+					uint8_t parsedValue = std::stoi(value);
+					SetByte(name, parsedValue);
+				}
+				return;
+
+				case ExpressionValueType::ValueInt:
+				{
+					uint32_t parsedValue = std::stoul(value);
+					SetInt(name, parsedValue);
+				}
+				return;
+
+				case ExpressionValueType::ValueBool:
+				{
+					if (value == "True" || value == "true" || value == "1")
+						SetBool(name, true);
+					else if (value == "False" || value == "false" || value == "0")
+						SetBool(name, false);
+					else
+						throw std::invalid_argument("Encountered a non-boolean value: " + value);
+				}
+				return;
+
+				case ExpressionValueType::ValueFloat:
+				{
+					double parsedValue = std::stod(value);
+					SetFloat(name, parsedValue);
+				}
+				return;
+
+				case ExpressionValueType::ValueObject:
+				{
+					auto properties = ParsePropertiesFromString(value);
+
+					if (properties.empty())
+						return;
+
+					UObject* foundObject = engine->FindObject(properties["Name"], properties["Class"]);
+
+					if (!foundObject)
+						return;
+
+					SetObject(name, foundObject);
+				}
+				return;
+
+				// These are all struct types
+				case ExpressionValueType::ValueVector:
+				case ExpressionValueType::ValueRotator:
+				case ExpressionValueType::ValueStruct:
+				case ExpressionValueType::ValueColor:
+					prop->SetValueFromString(PropertyData.Ptr(prop), value);
+					return;
+
+				case ExpressionValueType::ValueString:
+					SetString(name, value);
+					return;
+
+				case ExpressionValueType::ValueName:
+					SetName(name, value);
+					return;
+			}
+		}
+			
 	}
 }
 

--- a/SurrealEngine/UObject/UProperty.h
+++ b/SurrealEngine/UObject/UProperty.h
@@ -80,6 +80,10 @@ static std::map<NameString, std::string> ParsePropertiesFromString(std::string p
 	if (propertiesString.empty())
 		return {};
 
+	// Also check for the string being "null" or "null struct"
+	if (propertiesString == "null" || propertiesString == "null struct")
+		return {};
+
 	if (propertiesString[0] != '{')
 		throw std::runtime_error("{ not found in the property string: " + propertiesString);
 

--- a/SurrealEngine/UObject/UProperty.h
+++ b/SurrealEngine/UObject/UProperty.h
@@ -186,7 +186,7 @@ public:
 	{
 		UObject* obj = *(UObject**)data;
 		if (obj)
-			return "{ name=\"" + obj->Name.ToString() + "\", class=" + UObject::GetUClassFullName(obj).ToString() + " }";
+			return "{ name=" + obj->Name.ToString() + ", class=" + UObject::GetUClassFullName(obj).ToString() + " }";
 		else
 			return "null";
 	}


### PR DESCRIPTION
We can "travel" the Weapon and SelectedItem properties of PlayerPawns now, albeit with some weird bugs.

Should be mostly fine unless you grab the two flares at the beginning of NyLeve, ghost towards the end, use both of the said flares THEN end the level.