### PR TITLE
ZWidget Wayland backend improvements (Part 1)

### DIFF
--- a/SurrealEngine/EditorApp.cpp
+++ b/SurrealEngine/EditorApp.cpp
@@ -25,7 +25,7 @@ int EditorApp::main(std::vector<std::string> args)
 		Engine engine(info);
 
 		auto editorWindow = std::make_unique<EditorMainWindow>();
-		editorWindow->SetFrameGeometry(Rect::xywh(0.0, 0.0, 1920.0, 1080.0));
+		editorWindow->SetFrameGeometry(Rect::xywh(0.0, 0.0, 1024.0, 768.0));
 		editorWindow->Show();
 
 		DisplayWindow::RunLoop();

--- a/Thirdparty/ZWidget/CMakeLists.txt
+++ b/Thirdparty/ZWidget/CMakeLists.txt
@@ -51,6 +51,8 @@ set(ZWIDGET_SOURCES
 	src/window/stub/stub_open_file_dialog.h
 	src/window/stub/stub_save_file_dialog.cpp
 	src/window/stub/stub_save_file_dialog.h
+	src/window/ztimer/ztimer.h
+	src/window/ztimer/ztimer.cpp
 	src/systemdialogs/open_folder_dialog.cpp
 	src/systemdialogs/open_file_dialog.cpp
 	src/systemdialogs/save_file_dialog.cpp

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -60,7 +60,7 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
     m_waylandOutput.on_mode() = [&] (wayland::output_mode flags, int32_t width, int32_t height, int32_t refresh) {
         m_ScreenSize = Size(width, height);
     };
-
+/*
     m_DataDevice = m_DataDeviceManager.get_data_device(m_waylandSeat);
 
     m_DataSource = m_DataDeviceManager.create_data_source();
@@ -106,7 +106,7 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
 
         dataOffer.proxy_release();
     };
-
+*/
     m_XDGWMBase.on_ping() = [&] (uint32_t serial) {
         m_XDGWMBase.pong(serial);
     };
@@ -254,7 +254,7 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
 
         OnKeyboardCharEvent(buf);
 
-        m_DataDevice.set_selection(m_DataSource, m_KeyboardSerial);
+        //m_DataDevice.set_selection(m_DataSource, m_KeyboardSerial);
     };
 
     m_cursorSurface = m_waylandCompositor.create_surface();
@@ -523,6 +523,8 @@ void WaylandDisplayWindow::ProcessEvents()
 
 void WaylandDisplayWindow::RunLoop()
 {
+    exitRunLoop = false;
+
     while (!exitRunLoop)
     {
         CheckNeedsUpdate();

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -262,8 +262,8 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
 
     m_waylandKeyboard.on_repeat_info() = [&] (int32_t rate, int32_t delay) {
         // rate is characters per second, delay is in milliseconds
-        m_keyboardDelayTimer.SetDuration(WLTimer::Duration(delay));
-        m_keyboardRepeatTimer.SetDuration(WLTimer::Duration(1000.0 / rate));
+        m_keyboardDelayTimer.SetDuration(ZTimer::Duration(delay));
+        m_keyboardRepeatTimer.SetDuration(ZTimer::Duration(1000.0 / rate));
     };
 
     m_cursorSurface = m_waylandCompositor.create_surface();
@@ -306,16 +306,16 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
     s_Windows.push_back(this);
     s_WindowsIterator = s_Windows.end();
 
-    m_keyboardDelayTimer = WLTimer();
-    m_keyboardRepeatTimer = WLTimer();
+    m_keyboardDelayTimer = ZTimer();
+    m_keyboardRepeatTimer = ZTimer();
 
     m_keyboardDelayTimer.SetCallback([&] () { OnKeyboardDelayEnd(); });
     m_keyboardRepeatTimer.SetCallback([&] () { OnKeyboardRepeat(); });
 
     m_keyboardRepeatTimer.SetRepeating(true);
 
-    m_previousTime = WLTimer::Clock::now();
-    m_currentTime = WLTimer::Clock::now();
+    m_previousTime = ZTimer::Clock::now();
+    m_currentTime = ZTimer::Clock::now();
 
     if (!popupWindow)
     {
@@ -595,7 +595,7 @@ void WaylandDisplayWindow::CheckNeedsUpdate()
 
 void WaylandDisplayWindow::UpdateTimers()
 {
-    m_currentTime = WLTimer::Clock::now();
+    m_currentTime = ZTimer::Clock::now();
 
     m_keyboardDelayTimer.Update(m_currentTime - m_previousTime);
     m_keyboardRepeatTimer.Update(m_currentTime - m_previousTime);

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -262,7 +262,6 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
 
     m_waylandKeyboard.on_repeat_info() = [&] (int32_t rate, int32_t delay) {
         // rate is characters per second, delay is in milliseconds
-        printf("RepeatInfo: rate = %d chars/sec - delay = %d milliseconds\n", rate, delay);
         m_keyboardDelayTimer.SetDuration(WLTimer::Duration(delay));
         m_keyboardRepeatTimer.SetDuration(WLTimer::Duration(1000.0 / rate));
     };
@@ -312,9 +311,6 @@ WaylandDisplayWindow::WaylandDisplayWindow(DisplayWindowHost* windowHost, bool p
 
     m_keyboardDelayTimer.SetCallback([&] () { OnKeyboardDelayEnd(); });
     m_keyboardRepeatTimer.SetCallback([&] () { OnKeyboardRepeat(); });
-
-    //m_keyboardDelayTimer.SetDuration(WLTimer::Duration(600));
-    //m_keyboardRepeatTimer.SetDuration(WLTimer::Duration(1000.0 / 25));
 
     m_keyboardRepeatTimer.SetRepeating(true);
 
@@ -637,7 +633,6 @@ void WaylandDisplayWindow::OnKeyboardCharEvent(const char* ch)
 
 void WaylandDisplayWindow::OnKeyboardDelayEnd()
 {
-    printf("Delay ended\n");
     if (inputKeyStates[previousKey])
         m_keyboardRepeatTimer.Start();
 }

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -337,7 +337,7 @@ WaylandDisplayWindow::~WaylandDisplayWindow()
     if (m_KeyboardState)
         xkb_state_unref(m_KeyboardState);
 
-    s_Windows.erase(s_WindowsIterator);
+    s_WindowsIterator = s_Windows.erase(s_WindowsIterator);
 }
 
 void WaylandDisplayWindow::SetWindowTitle(const std::string& text)

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "wayland_display_backend.h"
+#include "window/ztimer/ztimer.h"
 
 #include <stdexcept>
 #include <array>
 #include <memory>
 #include <sstream>
-#include <ctime>
-#include <chrono>
+
 #include <algorithm>
 #include <random>
 #include <map>
@@ -87,85 +87,6 @@ private:
     int fd = 0;
     size_t len = 0;
     void *mem = nullptr;
-};
-
-class WLTimer
-{
-public:
-    using Duration = std::chrono::duration<double, std::milli>;
-    using Clock = std::chrono::system_clock;
-    using TimePoint = std::chrono::time_point<Clock, Duration>;
-    WLTimer() {}
-
-    WLTimer(Duration duration_ms) : m_timerDuration(duration_ms) {}
-
-    WLTimer(Duration duration_ms, std::function<void()> callback)
-        : m_timerDuration(duration_ms), m_callback(callback)
-        {}
-
-    ~WLTimer() {
-        Stop();
-    }
-
-    void Start() {
-        m_startTime = Clock::now();
-        m_currentTime = m_startTime;
-        m_timerStarted = true;
-        m_timerFinished = false;
-    }
-
-    void Stop() {
-        m_timerStarted = false;
-    }
-
-    void SetDuration(Duration duration_ms) {
-        if (m_timerStarted)
-            return;
-        m_timerDuration = duration_ms;
-    }
-
-    void SetCallback(std::function<void()> callback) {
-        if (m_timerStarted)
-            return;
-        m_callback = callback;
-    }
-
-    void SetRepeating(bool value) {
-        if (m_timerStarted)
-            return;
-        m_repeatingTimer = value;
-    }
-
-    void Update(Duration deltaTime) {
-        if (!m_timerStarted)
-            return;
-
-        m_currentTime += deltaTime;
-
-        if (m_currentTime >= m_startTime + m_timerDuration)
-        {
-            m_callback();
-            if (!m_repeatingTimer)
-            {
-                Stop();
-                m_timerFinished = true;
-            }
-            else
-                Start();
-        }
-    }
-
-    bool IsStarted() { return m_timerStarted; }
-    bool IsFinished() { return m_timerFinished; }
-private:
-    bool m_timerStarted = false;
-    bool m_repeatingTimer = false;
-    bool m_timerFinished = false;
-
-    TimePoint m_startTime;
-    TimePoint m_currentTime;
-    Duration m_timerDuration;
-    std::function<void()> m_callback;
 };
 
 class WaylandDisplayWindow : public DisplayWindow
@@ -281,11 +202,11 @@ private:
     bool hasKeyboard = false;
     bool hasPointer = false;
 
-    WLTimer::TimePoint m_previousTime;
-    WLTimer::TimePoint m_currentTime;
+    ZTimer::TimePoint m_previousTime;
+    ZTimer::TimePoint m_currentTime;
 
-    WLTimer m_keyboardDelayTimer;
-    WLTimer m_keyboardRepeatTimer;
+    ZTimer m_keyboardDelayTimer;
+    ZTimer m_keyboardRepeatTimer;
 
     void UpdateTimers();
 

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -171,12 +171,12 @@ private:
 
     Point m_SurfaceMousePos = Point(0, 0);
 
-    static Size m_ScreenSize;
+    static Size s_ScreenSize;
     static std::vector<WaylandDisplayWindow*> s_Windows;
     static std::vector<WaylandDisplayWindow*>::iterator s_WindowsIterator;
 
-    static wayland::display_t m_waylandDisplay;
-    static wayland::registry_t m_waylandRegistry;
+    static wayland::display_t s_waylandDisplay;
+    static wayland::registry_t s_waylandRegistry;
     wayland::compositor_t m_waylandCompositor;
     wayland::shm_t m_waylandSHM;
     wayland::seat_t m_waylandSeat;

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <random>
 #include <map>
-#include <list>
+#include <vector>
 
 #include <wayland-client.hpp>
 #include <wayland-client-protocol-extra.hpp>
@@ -231,6 +231,7 @@ private:
     void OnMouseReleaseEvent(InputKey button);
     void OnMouseMoveEvent(Point surfacePos);
     void OnMouseWheelEvent(InputKey button);
+    void OnExportHandleEvent(std::string exportedHandle);
     void OnExitEvent();
 
     void DrawSurface(uint32_t serial = 0);
@@ -250,8 +251,8 @@ private:
     Point m_SurfaceMousePos = Point(0, 0);
 
     static Size m_ScreenSize;
-    static std::list<WaylandDisplayWindow*> s_Windows;
-    static std::list<WaylandDisplayWindow*>::iterator s_WindowsIterator;
+    static std::vector<WaylandDisplayWindow*> s_Windows;
+    static std::vector<WaylandDisplayWindow*>::iterator s_WindowsIterator;
 
     static wayland::display_t m_waylandDisplay;
     static wayland::registry_t m_waylandRegistry;

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -174,7 +174,7 @@ private:
     static std::list<WaylandDisplayWindow*>::iterator s_WindowsIterator;
 
     static wayland::display_t m_waylandDisplay;
-    wayland::registry_t m_waylandRegistry;
+    static wayland::registry_t m_waylandRegistry;
     wayland::compositor_t m_waylandCompositor;
     wayland::shm_t m_waylandSHM;
     wayland::seat_t m_waylandSeat;

--- a/Thirdparty/ZWidget/src/window/ztimer/ztimer.cpp
+++ b/Thirdparty/ZWidget/src/window/ztimer/ztimer.cpp
@@ -1,0 +1,73 @@
+#include "ztimer.h"
+
+ZTimer::ZTimer()
+{
+}
+
+ZTimer::ZTimer(Duration duration_ms) : m_timerDuration(duration_ms)
+{
+}
+
+ZTimer::ZTimer(Duration duration_ms, CallbackFunc callback)
+            : m_timerDuration(duration_ms), m_callback(callback)
+{
+}
+
+ZTimer::~ZTimer()
+{
+    Stop();
+}
+
+void ZTimer::Start()
+{
+    m_startTime = Clock::now();
+    m_currentTime = m_startTime;
+    m_timerStarted = true;
+    m_timerFinished = false;
+}
+
+void ZTimer::Stop()
+{
+    m_timerStarted = false;
+}
+
+void ZTimer::SetDuration(Duration duration_ms)
+{
+    if (m_timerStarted)
+        return;
+    m_timerDuration = duration_ms;
+}
+
+void ZTimer::SetCallback(std::function<void()> callback)
+{
+    if (m_timerStarted)
+        return;
+    m_callback = callback;
+}
+
+void ZTimer::SetRepeating(bool value)
+{
+    if (m_timerStarted)
+        return;
+    m_repeatingTimer = value;
+}
+
+void ZTimer::Update(Duration deltaTime)
+{
+    if (!m_timerStarted)
+        return;
+
+    m_currentTime += deltaTime;
+
+    if (m_currentTime >= m_startTime + m_timerDuration)
+    {
+        m_callback();
+        if (!m_repeatingTimer)
+        {
+            Stop();
+            m_timerFinished = true;
+        }
+        else
+            Start();
+    }
+}

--- a/Thirdparty/ZWidget/src/window/ztimer/ztimer.h
+++ b/Thirdparty/ZWidget/src/window/ztimer/ztimer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+
+// ZTimer: A small, independent timer
+// Useful for implementing timed events on your backends
+class ZTimer
+{
+public:
+    using Duration = std::chrono::duration<double, std::milli>;
+    using Clock = std::chrono::system_clock;
+    using TimePoint = std::chrono::time_point<Clock, Duration>;
+    using CallbackFunc = std::function<void()>;
+
+    ZTimer();
+    ZTimer(Duration duration_ms);
+    ZTimer(Duration duration_ms, CallbackFunc callback);
+
+    ~ZTimer();
+
+    void Start();
+    void Stop();
+    void SetDuration(Duration duration_ms);
+    void SetCallback(CallbackFunc callback);
+    void SetRepeating(bool value);
+    void Update(Duration deltaTime);
+
+    bool IsStarted() { return m_timerStarted; }
+    bool IsFinished() { return m_timerFinished; }
+
+private:
+    bool m_timerStarted = false;
+    bool m_repeatingTimer = false;
+    bool m_timerFinished = false;
+
+    TimePoint m_startTime;
+    TimePoint m_currentTime;
+    Duration m_timerDuration;
+    CallbackFunc m_callback;
+};


### PR DESCRIPTION
Known bugs from the initial PR is now fixed. Now you can run SurrealEditor and the launcher window disappears once you start the game/editor.

Alongside that:
* Menus are now working (a bit buggy though).
* Open file dialog is now working.
* Implemented key repeat functionality using a custom made timer class. This new timer can be used by other backends as well.

Menu bugs:
* They're not being positioned properly
* Switching between menus can crash the app sometimes
* They don't stay open when you stop clicking
* Their states don't match with the mouse pointer's position (wrong item gets highlighted)