### PR TITLE
Add detection of various games

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ At the time of this writing, SurrealEngine can detect the following UE1 games:
 
 * Unreal Tournament (v436, v451b, v469(a, b, c, d))
 * Unreal (v200, v209, v220, v224v, v225f, v226f)
-* Unreal Gold (v226b, v227(i, j))
+* Unreal Gold (v226b, v227(i, j, k_11))
 * Deus Ex (v1002f, v1112fm)
 * Klingon Honor Guard (219)
 * NERF Arena Blast (v300)
 * TNN Outdoors Pro Hunter (v200)
 * Rune Classic (v1.10)
+* Clive Barker's Undying (v420)
 * Tactical-Ops: Assault on Terror (v3.4.0 and v3.5.0 - both running under UT436 and UT469 engines)
-* Wheel of Time (v333s)
-
-Clive Barker's Undying (v420) is also in the database, but there is no corresponding SHA1sum for its executable file yet.
+* Wheel of Time (v333)
 
 From the list above, only Unreal Tournament v436 and Unreal Gold v226 is in a relatively playable state. Running any other game (and UT versions) can and will result in crashes.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ At the time of this writing, SurrealEngine can detect the following UE1 games:
 * TNN Outdoors Pro Hunter (v200)
 * Rune Classic (v1.10)
 * Tactical-Ops: Assault on Terror (v3.4.0 and v3.5.0 - both running under UT436 and UT469 engines)
+* Wheel of Time (v333s)
 
 Clive Barker's Undying (v420) is also in the database, but there is no corresponding SHA1sum for its executable file yet.
 

--- a/SurrealEngine/GameFolder.cpp
+++ b/SurrealEngine/GameFolder.cpp
@@ -141,6 +141,14 @@ GameLaunchInfo GameFolderSelection::ExamineFolder(const std::string& path)
 				info.gameVersionString = "227j";
 			}
 			break;
+			case KnownUE1Games::UNREALGOLD_227k_11:
+			{
+				info.gameName = "Unreal";
+				info.engineVersion = 227;
+				info.engineSubVersion = 11;
+				info.gameVersionString = "227k_11";
+			}
+			break;
 			case KnownUE1Games::UT99_436:
 			{
 				info.gameName = "Unreal Tournament";
@@ -235,6 +243,14 @@ GameLaunchInfo GameFolderSelection::ExamineFolder(const std::string& path)
 				info.engineVersion = 110;
 				info.engineSubVersion = 0;
 				info.gameVersionString = "1.10";
+			}
+			break;
+			case KnownUE1Games::UNDYING_420:
+			{
+				info.gameName = "Clive Barker's Undying";
+				info.engineVersion = 420;
+				info.engineSubVersion = 0;
+				info.gameVersionString = "420";
 			}
 			break;
 			case KnownUE1Games::TACTICAL_OPS_436:

--- a/SurrealEngine/GameFolder.cpp
+++ b/SurrealEngine/GameFolder.cpp
@@ -254,6 +254,14 @@ GameLaunchInfo GameFolderSelection::ExamineFolder(const std::string& path)
 				info.gameVersionString = "469d";
 			}
 			break;
+			case KnownUE1Games::WHEELOFTIME_333:
+			{
+				info.gameName = "Wheel of Time";
+				info.engineVersion = 333;
+				info.engineSubVersion = 0;
+				info.gameVersionString = "333";
+			}
+			break;
 		}
 	}
 	

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -251,7 +251,13 @@ std::unique_ptr<IniFile> PackageManager::GetIniFile(NameString iniName)
 	if (userIni && launchInfo.engineVersion > 219)
 		iniName = "User";
 	if (iniName == "system" || iniName == "System" || (userIni && launchInfo.engineVersion == 219))
-		iniName = launchInfo.gameExecutableName;
+	{
+		// Clive Barker's Undying uses System.ini instead of ExeName.ini
+		if (IsCliveBarkersUndying())
+			iniName = "System";
+		else
+			iniName = launchInfo.gameExecutableName;
+	}
 
 	return std::make_unique<IniFile>(*iniFiles[iniName]);
 }
@@ -262,8 +268,14 @@ std::unique_ptr<IniFile>& PackageManager::GetSystemIniFile(NameString iniName)
 	if (userIni && launchInfo.engineVersion > 219)
 		iniName = "User";
 	if (iniName == "system" || iniName == "System" || (userIni && launchInfo.engineVersion == 219))
-		iniName = launchInfo.gameExecutableName;
-
+	{
+		// Clive Barker's Undying uses System.ini instead of ExeName.ini
+		if (IsCliveBarkersUndying())
+			iniName = "System";
+		else
+			iniName = launchInfo.gameExecutableName;
+	}
+	
 	auto& ini = iniFiles[iniName];
 	if (!ini)
 	{
@@ -341,8 +353,11 @@ void PackageManager::LoadEngineIniFiles()
 		missing_se_system_ini = true;
 		engine_ini_name = engine_ini_name.substr(3); // Trim off the "SE-" part
 	}
-		
-	iniFiles[launchInfo.gameExecutableName] = std::make_unique<IniFile>(FilePath::combine(system_folder, engine_ini_name));
+	
+	if (IsCliveBarkersUndying())
+		iniFiles["System"] = std::make_unique<IniFile>(FilePath::combine(system_folder, "System.ini"));
+	else
+		iniFiles[launchInfo.gameExecutableName] = std::make_unique<IniFile>(FilePath::combine(system_folder, engine_ini_name));
 
 	if (launchInfo.engineVersion > 209)
 	{

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -28,6 +28,7 @@ public:
 	bool IsUnrealTournament() const { return launchInfo.gameExecutableName == "UnrealTournament"; }
 	bool IsUnrealTournament_469() const { return IsUnrealTournament() && launchInfo.engineVersion == 469; }
 	bool IsDeusEx() const { return launchInfo.gameExecutableName == "DeusEx"; }
+	bool IsCliveBarkersUndying() const { return launchInfo.gameExecutableName == "Undying"; }
 
 	int GetEngineVersion() const { return launchInfo.engineVersion; }
 	int GetEngineSubVersion() const { return launchInfo.engineSubVersion; }

--- a/SurrealEngine/UE1GameDatabase.h
+++ b/SurrealEngine/UE1GameDatabase.h
@@ -17,6 +17,7 @@ enum class KnownUE1Games
 	UNREALGOLD_226b,
 	UNREALGOLD_227i,
 	UNREALGOLD_227j,
+	UNREALGOLD_227k_11,
 	UT99_400,
 	UT99_436,
 	UT99_451,
@@ -69,6 +70,16 @@ static const std::map<std::string, KnownUE1Games> SHA1Database = {
 	{"a613cfcb78ad38190a8612a5267af1c6052ab95d", KnownUE1Games::UNREALGOLD_227j},
 	// Linux, 64 bit
 	{"60425d1dc310e49f1aa0d05c81abc3195f0b03d9", KnownUE1Games::UNREALGOLD_227j},
+
+	// Unreal Gold, 227k_11, Windows + Linux versions (32 + 64 bit)
+	// Windows 32 bit
+	{"2e32d9900ead5ab97812d9018a85850732c58b12", KnownUE1Games::UNREALGOLD_227k_11},
+	// Windows 64 bit
+	{"1f1c32b2ff52dd8232536216b2ffaaf519c975dc", KnownUE1Games::UNREALGOLD_227k_11},
+	// Linux 32 bit
+	{"a613cfcb78ad38190a8612a5267af1c6052ab95d", KnownUE1Games::UNREALGOLD_227k_11},
+	// Linux 64 bit
+	{"60425d1dc310e49f1aa0d05c81abc3195f0b03d9", KnownUE1Games::UNREALGOLD_227k_11},
 
 	// Unreal Tournament, v436, Windows version
 	// (TODO: get sha1sum of the Linux version)
@@ -133,6 +144,9 @@ static const std::map<std::string, KnownUE1Games> SHA1Database = {
 	// Rune Classic, Version 1.10
 	{"4a517c7f96a27cf7e25534c80d50af8db4065276", KnownUE1Games::RUNE_110},
 
+	// Clive Barker's Undying, Version 420 (GOG)
+	{"65aa7c5caca6495681c9c2dc919645de5c15b96e", KnownUE1Games::UNDYING_420},
+
 	// TNN Outdoors Pro Hunter
 	{"f4fbacdaaee360794187c8224f51ea82bd902a43", KnownUE1Games::TNN_200},
 
@@ -159,6 +173,7 @@ static const std::vector<std::string> knownUE1ExecutableNames = {
 	"Khg.exe",
 	"Nerf.exe",
 	"Rune.exe",
+	"Undying.exe",
 	"Spore.exe",
 	"TnnHunt.exe",
 	"TacticalOps.exe",

--- a/SurrealEngine/UE1GameDatabase.h
+++ b/SurrealEngine/UE1GameDatabase.h
@@ -33,6 +33,7 @@ enum class KnownUE1Games
 	UNDYING_420,
 	TACTICAL_OPS_436,
 	TACTICAL_OPS_469,
+	WHEELOFTIME_333,
 };
 
 static const std::map<std::string, KnownUE1Games> SHA1Database = {
@@ -141,6 +142,9 @@ static const std::map<std::string, KnownUE1Games> SHA1Database = {
 	// v3.4.0 and v3.5.0, running on UT v469 engine
 	// Has identical hash to UT v469d executable
 	// {"78c65e9434b442b15820d863136bb5a44700ad26", KnownUE1Games::TACTICAL_OPS_469},
+
+	// Wheel of Time, version 333 (GOG)
+	{"102013ab6e4535a515c7c589d0b5cdd484ef8fdd", KnownUE1Games::WHEELOFTIME_333},
 };
 
 static const std::vector<std::string> knownUE1ExecutableNames = {
@@ -157,7 +161,8 @@ static const std::vector<std::string> knownUE1ExecutableNames = {
 	"Rune.exe",
 	"Spore.exe",
 	"TnnHunt.exe",
-	"TacticalOps.exe"
+	"TacticalOps.exe",
+	"WoT.exe"
 };
 
 // Returns a pair of UE1-Game type and executable name


### PR DESCRIPTION
The ones added are:

* Wheel of Time (version 333, the one GOG version has by default): Currently crashes with an "invalid stoi argument" exception.
* Clive Barker's Undying (version 420, also from GOG): Currently crashes with an "unexpected end of file" exception.
* Unreal 227k_11: Haven't tested but this will be pretty similar to other 227 versions, as in it won't run because we haven't implemented 227 specific stuff yet.