### PR TITLE
IniFile: Skip over C++ style comments as well

### DIFF
--- a/SurrealEngine/Package/IniFile.cpp
+++ b/SurrealEngine/Package/IniFile.cpp
@@ -25,7 +25,9 @@ IniFile::IniFile(const std::string& filename)
 	std::string sectionName;
 	while (ReadLine(text, pos, line))
 	{
-		if (line.empty() || line[0] == ';')
+		// Skip comments and empty lines
+		// While ini files have ; as their comment indicator, some files in Wheel of Time use the good ol' // for some reason
+		if (line.empty() || line[0] == ';' || (line[0] == '/' && line[1] == '/'))
 			continue;
 
 		if (line.size() >= 2 && line.front() == '[' && line.back() == ']')


### PR DESCRIPTION
This fixes the "invalid stoi argument" error that happens when you try to run Wheel of Time. Apparently some of its ini files used C++ style "//" comments (normally they are denoted with ";"), which we did NOT ignore; and the said ini keys contained "x" as an index (because they're meant as examples), which we tried to read them as numbers to our certain doom.

Sadly, the game still doesn't run though.