### PR TITLE
Add additional folders to check for SurrealEngine.pk3 on Linux

### DIFF
--- a/SurrealEngine/UI/WidgetResourceData.cpp
+++ b/SurrealEngine/UI/WidgetResourceData.cpp
@@ -10,7 +10,7 @@ void InitWidgetResources()
 {
 	mz_bool result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(OS::executable_path(), "SurrealEngine.pk3").c_str(), 0);
 #ifndef WIN32
-	// On Linux, SurrealEngine.pk3 can additionally be put in /usr/share/surrealengine
+	// On Linux, SurrealEngine.pk3 can additionally be put in some other folders given below.
 	if (!result)
 		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("/usr/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
 	if (!result)

--- a/SurrealEngine/UI/WidgetResourceData.cpp
+++ b/SurrealEngine/UI/WidgetResourceData.cpp
@@ -9,6 +9,11 @@ static mz_zip_archive widgetResources;
 void InitWidgetResources()
 {
 	mz_bool result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(OS::executable_path(), "SurrealEngine.pk3").c_str(), 0);
+#ifndef WIN32
+	// On Linux, SurrealEngine.pk3 can additionally be put in /usr/share/surrealengine
+	if (!result)
+		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("/usr/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
+#endif
 	if (!result)
 		Exception::Throw("Could not open SurrealEngine.pk3");
 }

--- a/SurrealEngine/UI/WidgetResourceData.cpp
+++ b/SurrealEngine/UI/WidgetResourceData.cpp
@@ -13,6 +13,10 @@ void InitWidgetResources()
 	// On Linux, SurrealEngine.pk3 can additionally be put in /usr/share/surrealengine
 	if (!result)
 		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("/usr/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
+	if (!result)
+		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("~/.local/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
+	if (!result)
+		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("~/.surrealengine", "SurrealEngine.pk3").c_str(), 0);
 #endif
 	if (!result)
 		Exception::Throw("Could not open SurrealEngine.pk3");


### PR DESCRIPTION
This should hopefully help with #129 (and packaging for Linux in general)

The folders that are checked are, in order:
* `/usr/share/surrealengine`
* `~/.local/share/surrealengine`
* `~/.surrealengine`