### PR TITLE
Fix finding home and use XDG standard when looking for SurrealEngine.pk3

### DIFF
--- a/SurrealEngine/UI/WidgetResourceData.cpp
+++ b/SurrealEngine/UI/WidgetResourceData.cpp
@@ -3,6 +3,8 @@
 #include "Utils/File.h"
 #include <miniz.h>
 #include "Utils/Exception.h"
+#include <cstdlib>
+#include <string>
 
 static mz_zip_archive widgetResources;
 
@@ -13,10 +15,20 @@ void InitWidgetResources()
 	// On Linux, SurrealEngine.pk3 can additionally be put in some other folders given below.
 	if (!result)
 		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("/usr/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
-	if (!result)
-		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("~/.local/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
-	if (!result)
-		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("~/.surrealengine", "SurrealEngine.pk3").c_str(), 0);
+	if (!result) {
+		char * home = std::getenv("HOME");
+		std::string directory = FilePath::combine(std::string(home) , ".local/share/surrealengine");
+		char * xdg_data_home = std::getenv("XDG_DATA_HOME");
+		if (xdg_data_home != NULL) {
+			directory = FilePath::combine(std::string(xdg_data_home), "surrealengine");
+		}
+		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(directory, "SurrealEngine.pk3").c_str(), 0);
+	}
+	if (!result) {
+		char * home = std::getenv("HOME");
+		std::string directory = FilePath::combine(std::string(home) , ".surrealengine");
+		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(directory, "SurrealEngine.pk3").c_str(), 0);
+	}
 #endif
 	if (!result)
 		Exception::Throw("Could not open SurrealEngine.pk3");


### PR DESCRIPTION
I found 2 issues with this code while testing it. One was that it used the XDG_DATA_HOME, but did not check the environment variable. The other was that `~` was not being expanded. This PR fixes both these issues.