### PR TITLE
Arch Linux instructions, slight PKGBUILD and README formatting changes.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=surrealengine-git
 pkgdesc="A reimplementation of Unreal Engine 1 (Git version)"
-pkgver=0.0.1
+pkgver=r1042.784a270
 pkgrel=1
 arch=('x86_64')
 depends=('libx11' 'spirv-tools' 'vulkan-icd-loader' 'vulkan-driver' 'sdl2' 'alsa-lib')

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ At the time of this writing, SurrealEngine can detect the following UE1 games:
 * Tactical-Ops: Assault on Terror (v3.4.0 and v3.5.0 - both running under UT436 and UT469 engines)
 * Wheel of Time (v333)
 
-From the list above, only Unreal Tournament v436 and Unreal Gold v226 is in a relatively playable state. Running any other game (and UT versions) can and will result in crashes.
+> [!NOTE]
+> From the list above, only Unreal Tournament v436 and Unreal Gold v226 is in a relatively playable state. Running any other game (and UT versions) can and will result in crashes.
 
 ### Unreal Tournament v436
 
@@ -77,6 +78,13 @@ Note that these packages won't always have the exact names given above, as it ca
 ### Ubuntu
 
     # apt install cmake g++ libasound-dev libopenal-dev libdbus-1-dev libsdl2-dev libxkbcommon-dev waylandpp-dev
+
+### Arch Linux
+
+> [!NOTE]
+> [An AUR package is available](https://aur.archlinux.org/packages/surrealengine-git).
+
+    # pacman -S libx11 gcc git cmake sdl2 alsa-lib waylandpp
 
 Once you've installed all of the prerequisites, enter these commands in the given order from the folder you want to clone the repo to:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ Only the intro flyby works. No keyboard or mouse inputs will be detected, as Deu
 
 You can simply copy paste the SurrealEngine executable inside the System folder of your UE1 game of choice, and run it from there. If no game folder is specified, and the executable isn't in a System folder, the engine will search the registry (Windows only) for the registry keys Epic originally set. If no URL is specified it will use the default URL in the ini file (per default the intro map). The --engineversion argument overrides the internal version detected by the engine and should only be used for debugging purposes.
 
-## Windows build instructions
+## Packages
+
+Surreal Engine is available on:
+
+* AUR: https://aur.archlinux.org/packages/surrealengine-git
+
+## Building Surreal Engine
+
+### Windows
 
 Use CMake to build the project. A recent version of Visual Studio, and MSVC compiler that supports C++17 is required.
 
@@ -59,7 +67,7 @@ On Windows, SDL2 is an optional dependency that you need to supply locally yours
 
 Other than that there are no other external third party dependencies.
 
-## Linux build instructions
+### Linux
 
 Use CMake to build the project. You're gonna need the development versions of the following packages:
 
@@ -75,16 +83,17 @@ On Linux, SDL2 is required, as SurrealEngine will utilise it for its windowing f
 
 Note that these packages won't always have the exact names given above, as it can change from distro to distro. In general, if you get an include error that looks like it is trying to include something external, then you are probably missing the dev package for that library. :)
 
-### Ubuntu
+#### Installing the prerequisite packages
+
+**Ubuntu**
 
     # apt install cmake g++ libasound-dev libopenal-dev libdbus-1-dev libsdl2-dev libxkbcommon-dev waylandpp-dev
 
-### Arch Linux
-
-> [!NOTE]
-> [An AUR package is available](https://aur.archlinux.org/packages/surrealengine-git).
+**Arch Linux**
 
     # pacman -S libx11 gcc git cmake sdl2 alsa-lib waylandpp
+
+#### After installing prerequisites
 
 Once you've installed all of the prerequisites, enter these commands in the given order from the folder you want to clone the repo to:
 


### PR DESCRIPTION
* Bump the package version to a revision number (which will be an old one) in PKGBUILD
* Update README with the prerequisite command on Arch Linux, provide a link to the AUR package, and do a small formatting change. 