### PR TITLE
Make sure libdbus is installed for Ubuntu in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
         if ("${{ runner.os }}" STREQUAL "Windows")
         elseif ("${{ runner.os }}" STREQUAL "Linux")
           execute_process(
-            COMMAND sudo apt-get install libsdl2-dev libopenal-dev
+            COMMAND sudo apt-get install libsdl2-dev libopenal-dev libdbus-1-dev
           )
         elseif ("${{ runner.os }}" STREQUAL "macOS")
           execute_process(


### PR DESCRIPTION
The GitHub action workflow was failing because the libdbus dev package was missing. This PR fixes that.