### PR TITLE
Math/mat,Render/BspClipper: Fix NOSSE ifdefs

### DIFF
--- a/SurrealEngine/Math/mat.cpp
+++ b/SurrealEngine/Math/mat.cpp
@@ -2,7 +2,7 @@
 #include "Precomp.h"
 #include "mat.h"
 #include <cmath>
-#ifndef NO_SSE
+#ifndef NOSSE
 #include <emmintrin.h>
 #endif
 #include <string.h>
@@ -199,7 +199,7 @@ mat4 mat4::operator*(const mat4 &mult) const
 
 vec4 mat4::operator*(const vec4 &v) const
 {
-#ifdef NO_SSE
+#ifdef NOSSE
 	vec4 result;
 	result.x = matrix[0 * 4 + 0] * v.x + matrix[1 * 4 + 0] * v.y + matrix[2 * 4 + 0] * v.z + matrix[3 * 4 + 0] * v.w;
 	result.y = matrix[0 * 4 + 1] * v.x + matrix[1 * 4 + 1] * v.y + matrix[2 * 4 + 1] * v.z + matrix[3 * 4 + 1] * v.w;

--- a/SurrealEngine/Render/BspClipper.cpp
+++ b/SurrealEngine/Render/BspClipper.cpp
@@ -3,7 +3,7 @@
 #include "BspClipper.h"
 #include "Math/bbox.h"
 
-#ifndef NO_SSE
+#ifndef NOSSE
 #include <immintrin.h>
 #endif
 
@@ -247,7 +247,7 @@ bool BspClipper::DrawTriangle(const vec4* const* vert, bool solid, bool ccw)
 	float viewport_width = (float)ViewportWidth;
 	float viewport_height = (float)ViewportHeight;
 
-#ifdef NO_SSE
+#ifdef NOSSE
 	// Map to 2D viewport:
 	for (int j = 0; j < numclipvert; j++)
 	{
@@ -356,7 +356,7 @@ int BspClipper::ClipEdge(const vec4* const* verts)
 
 	// halfspace clip distances
 	static const int numclipdistances = 6; // 9;
-#ifdef NO_SSE
+#ifdef NOSSE
 	float clipdistance[numclipdistances * 3];
 	bool needsclipping = false;
 	float* clipd = clipdistance;
@@ -441,7 +441,7 @@ int BspClipper::ClipEdge(const vec4* const* verts)
 		for (int i = 0; i < inputverts; i++)
 		{
 			int j = (i + 1) % inputverts;
-#ifdef NO_SSE
+#ifdef NOSSE
 			float clipdistance1 =
 				clipdistance[0 * numclipdistances + p] * input[i * 3 + 0] +
 				clipdistance[1 * numclipdistances + p] * input[i * 3 + 1] +


### PR DESCRIPTION
Define is called `NOSSE`, not `NO_SSE`.

https://github.com/dpjudas/SurrealEngine/blob/b6718beb8f1ab8768623fe31134b8f96abb38bfa/SurrealEngine/Precomp.h#L30

Fixes building on aarch64-linux.