### PR TITLE
ZWidget Wayland Backend - Window handle fixes

### DIFF
--- a/Thirdparty/ZWidget/include/zwidget/window/waylandnativehandle.h
+++ b/Thirdparty/ZWidget/include/zwidget/window/waylandnativehandle.h
@@ -1,7 +1,6 @@
 #pragma once
 
-struct wl_display;
-struct wl_surface;
+#include <wayland-client-protocol.h>
 
 class WaylandNativeHandle
 {

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
@@ -411,7 +411,6 @@ std::unique_ptr<DisplayWindow> WaylandDisplayBackend::Create(DisplayWindowHost* 
 void WaylandDisplayBackend::OnWindowCreated(WaylandDisplayWindow* window)
 {
     s_Windows.push_back(window);
-	m_FocusWindow = window;
 }
 
 void WaylandDisplayBackend::OnWindowDestroyed(WaylandDisplayWindow* window)

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
@@ -361,12 +361,14 @@ void WaylandDisplayBackend::OnMouseLeaveEvent()
 
 void WaylandDisplayBackend::OnMousePressEvent(InputKey button)
 {
-    m_FocusWindow->windowHost->OnWindowMouseDown(m_FocusWindow->m_SurfaceMousePos, button);
+    if (m_FocusWindow)
+        m_FocusWindow->windowHost->OnWindowMouseDown(m_FocusWindow->m_SurfaceMousePos, button);
 }
 
 void WaylandDisplayBackend::OnMouseReleaseEvent(InputKey button)
 {
-    m_FocusWindow->windowHost->OnWindowMouseUp(m_FocusWindow->m_SurfaceMousePos, button);
+    if (m_FocusWindow)
+        m_FocusWindow->windowHost->OnWindowMouseUp(m_FocusWindow->m_SurfaceMousePos, button);
 }
 
 void WaylandDisplayBackend::OnMouseMoveEvent(Point surfacePos)
@@ -380,7 +382,8 @@ void WaylandDisplayBackend::OnMouseMoveEvent(Point surfacePos)
 
 void WaylandDisplayBackend::OnMouseWheelEvent(InputKey button)
 {
-    m_FocusWindow->windowHost->OnWindowMouseWheel(m_FocusWindow->m_SurfaceMousePos, button);
+    if (m_FocusWindow)
+        m_FocusWindow->windowHost->OnWindowMouseWheel(m_FocusWindow->m_SurfaceMousePos, button);
 }
 
 void WaylandDisplayBackend::SetCursor(StandardCursor cursor)

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
@@ -411,6 +411,8 @@ std::unique_ptr<DisplayWindow> WaylandDisplayBackend::Create(DisplayWindowHost* 
 void WaylandDisplayBackend::OnWindowCreated(WaylandDisplayWindow* window)
 {
     s_Windows.push_back(window);
+    if (!window->m_PopupWindow)
+        m_FocusWindow = window;
 }
 
 void WaylandDisplayBackend::OnWindowDestroyed(WaylandDisplayWindow* window)

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "zwidget/window/window.h"
+#include "zwidget/window/waylandnativehandle.h"
 
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -124,7 +125,7 @@ public:
 	Point MapFromGlobal(const Point& pos) const override;
 	Point MapToGlobal(const Point& pos) const override;
 
-    void* GetNativeHandle() override { return (void*)&m_XDGToplevel; }
+    void* GetNativeHandle() override { return (void*)&m_NativeHandle; }
     wayland::surface_t GetWindowSurface() { return m_AppSurface; }
 
 private:
@@ -151,6 +152,9 @@ private:
     double m_ScaleFactor = 1.0;
 
     Point m_SurfaceMousePos = Point(0, 0);
+
+    WaylandNativeHandle m_NativeHandle;
+    RenderAPI m_renderAPI;
 
     wayland::data_device_t m_DataDevice;
     wayland::data_source_t m_DataSource;

--- a/bugs.txt
+++ b/bugs.txt
@@ -14,8 +14,6 @@ Engine general:
 All they currently do is to sometimes retaliate if attacked, and pick up nearby items.
 * Bots literally rotate their entire body (feet off the ground) to look up/down in ways they shouldn't be able to.
 * Decals don't clip to BSP correctly, or sometimes do not appear at all.
-* Parsing UClasses from Strings (e.g. class'UnrealShare.DispersionPistol') is not implemented,
-causing a crash because SE tries to parse them like UObjects.
 * Waving water textures at the end of waterfalls render broken. Easily observable in NyLeve's Falls (Unreal) or DM-ArcaneTemple (UT)
 * Inventory travelling is quite buggy: Either they travel, but get deselected upon the next level load, or cause a crash.
 And not all travel types are implemented.
@@ -36,12 +34,10 @@ they end up dying because SE thinks that they've fallen from a great height.
 * By design, native mods will never work with SE. Thankfully these kind of mods are extremely rare.
 * [Linux/ZWidget] Wayland backend is extremely buggy due to Wayland APIs being unpleasant to work with, to name a few things:
  - Menus don't properly position themselves.
- - Switching menus rapidly sometimes leads to a crash.
- - Assigning a wl_surface as a Vulkan surface crashes SurrealEditor, because Vulkan tries to "own" the surface(?) while the app itself also tries the same
- causing a protocol error due to explicit sync.
+ - Sometimes menus remain persistent (due to rapidly switching?), if the user then tries to resize the parent window, it causes a crash.
  - Running any ZWidget app (launcher/SurrealEditor) on GNOME will probably lead to not being able to move the window around, 
  because ZWidget has no custom window decorations (ZWidget uses server side decorations when they're available)
- - Currently SurrealEditor crashes immediately due to a queue assertion failure.
+ - SurrealEngine produces a black screen that is not interactable in any way, while SurrealEditor crashes when trying to open a map
 
 Engine general - Needs testing:
 -------------------------------


### PR DESCRIPTION
This fixes the painful `assertion "proxy->display" == "queue->display" failed` error. The main problem was not sending a proper handle.

SurrealEditor actually opens up now! Though nothing much can be done because opening up a map crashes the editor.

SurrealEngine only shows a black screen, which is not interactable in any way.

Still, much better than what we previously had.