### PR TITLE
Further ZWidget Wayland Backend fixes

### DIFF
--- a/SurrealEngine/GameApp.cpp
+++ b/SurrealEngine/GameApp.cpp
@@ -16,9 +16,7 @@
 
 int GameApp::main(Array<std::string> args)
 {
-	//auto backend = DisplayBackend::TryCreateBackend();
-	auto backend = DisplayBackend::TryCreateWin32();
-	if (!backend) backend = DisplayBackend::TryCreateSDL2();
+	auto backend = DisplayBackend::TryCreateBackend();
 	DisplayBackend::Set(std::move(backend));
 	InitWidgetResources();
 	WidgetTheme::SetTheme(std::make_unique<DarkWidgetTheme>());

--- a/Thirdparty/ZWidget/CMakeLists.txt
+++ b/Thirdparty/ZWidget/CMakeLists.txt
@@ -5,6 +5,7 @@ if (UNIX AND NOT APPLE)
 	include(FindPkgConfig)
 	pkg_check_modules(DBUS REQUIRED dbus-1)
 	pkg_check_modules(WAYLANDPP
+		wayland-client
 		wayland-client++
 		wayland-client-extra++
 		wayland-client-unstable++

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
@@ -789,6 +789,11 @@ InputKey WaylandDisplayBackend::XKBKeySymToInputKey(xkb_keysym_t keySym)
             return InputKey::Tilde;
         case XKB_KEY_apostrophe:
             return InputKey::SingleQuote;
+        case XKB_KEY_KP_Enter:
+        case XKB_KEY_Return:
+            return InputKey::Enter;
+        case XKB_KEY_space:
+            return InputKey::Space;
 
         case XKB_KEY_Up:
             return InputKey::Up;

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.cpp
@@ -1031,6 +1031,11 @@ InputKey WaylandDisplayBackend::LinuxInputEventCodeToInputKey(uint32_t inputCode
             return InputKey::Tilde;
         case KEY_APOSTROPHE:
             return InputKey::SingleQuote;
+        case KEY_SPACE:
+            return InputKey::Space;
+        case KEY_ENTER:
+        case KEY_KPENTER:
+            return InputKey::Enter;
 
         case KEY_UP:
             return InputKey::Up;

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.h
@@ -3,14 +3,25 @@
 #include "window/window.h"
 #include "window/ztimer/ztimer.h"
 
+#include <wayland-client.h>
 #include <wayland-client.hpp>
 #include <wayland-client-protocol-extra.hpp>
 #include <wayland-client-protocol-unstable.hpp>
 #include <wayland-cursor.hpp>
 #include "wl_fractional_scaling_protocol.hpp"
 #include <linux/input.h>
+#include <poll.h>
 #include <map>
 #include <xkbcommon/xkbcommon.h>
+
+static short poll_single(int fd, short events, int timeout) {
+    pollfd pfd { .fd = fd, .events = events, .revents = 0 };
+    if (0 > poll(&pfd, 1, timeout)) {
+        throw std::runtime_error("poll() failed");
+    }
+
+    return pfd.revents;
+}
 
 class WaylandDisplayWindow;
 

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.h
@@ -23,6 +23,37 @@ static short poll_single(int fd, short events, int timeout) {
     return pfd.revents;
 }
 
+enum pointer_event_mask {
+       POINTER_EVENT_ENTER = 1 << 0,
+       POINTER_EVENT_LEAVE = 1 << 1,
+       POINTER_EVENT_MOTION = 1 << 2,
+       POINTER_EVENT_BUTTON = 1 << 3,
+       POINTER_EVENT_AXIS = 1 << 4,
+       POINTER_EVENT_AXIS_SOURCE = 1 << 5,
+       POINTER_EVENT_AXIS_STOP = 1 << 6,
+       POINTER_EVENT_AXIS_DISCRETE = 1 << 7,
+       POINTER_EVENT_AXIS_120 = 1 << 8,
+       POINTER_EVENT_RELATIVE_MOTION = 1 << 9,
+};
+
+struct WaylandPointerEvent
+{
+    uint32_t event_mask;
+    double surfaceX, surfaceY;
+    double dx, dy;
+    uint32_t button;
+    wayland::pointer_button_state state;
+    uint32_t time;
+    uint32_t serial;
+    struct {
+        bool valid;
+        double value;
+        int32_t discrete;
+        int32_t value120;
+    } axes[2];
+    wayland::pointer_axis_source axis_source;
+};
+
 class WaylandDisplayWindow;
 
 class WaylandDisplayBackend : public DisplayBackend
@@ -81,6 +112,9 @@ public:
     wayland::keyboard_t m_waylandKeyboard;
     wayland::pointer_t m_waylandPointer;
 
+    wayland::zwp_relative_pointer_manager_v1_t m_RelativePointerManager;
+    wayland::zwp_relative_pointer_v1_t m_RelativePointer;
+
     wayland::cursor_image_t m_cursorImage;
     wayland::surface_t m_cursorSurface;
     wayland::buffer_t m_cursorBuffer;
@@ -129,4 +163,6 @@ private:
     xkb_context* m_KeymapContext = nullptr;
     xkb_keymap* m_Keymap = nullptr;
     xkb_state* m_KeyboardState = nullptr;
+
+    WaylandPointerEvent currentPointerEvent = {0};
 };

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_backend.h
@@ -62,6 +62,7 @@ public:
 	wayland::registry_t s_waylandRegistry;
 	std::vector<WaylandDisplayWindow*> s_Windows;
 	WaylandDisplayWindow* m_FocusWindow = nullptr;
+    WaylandDisplayWindow* m_MouseFocusWindow = nullptr; // Mouse focus should be tracked separately.
 
     wayland::compositor_t m_waylandCompositor;
     wayland::shm_t m_waylandSHM;
@@ -86,6 +87,9 @@ public:
 
     std::map<InputKey, bool> inputKeyStates; // True when the key is pressed, false when isn't
 
+    bool IsMouseLocked() { return hasMouseLock; }
+    void SetMouseLocked(bool val) { hasMouseLock = val; }
+
 private:
     void CheckNeedsUpdate();
 	void UpdateTimers();
@@ -99,6 +103,7 @@ private:
     void OnMousePressEvent(InputKey button);
     void OnMouseReleaseEvent(InputKey button);
     void OnMouseMoveEvent(Point surfacePos);
+    void OnMouseMoveRawEvent(int surfaceX, int surfaceY);
     void OnMouseWheelEvent(InputKey button);
 
     InputKey XKBKeySymToInputKey(xkb_keysym_t keySym);
@@ -108,6 +113,7 @@ private:
 
     bool hasKeyboard = false;
     bool hasPointer = false;
+    bool hasMouseLock = false;
 
     ZTimer::TimePoint m_previousTime;
     ZTimer::TimePoint m_currentTime;

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -197,27 +197,30 @@ void WaylandDisplayWindow::ShowCursor(bool enable)
 
 void WaylandDisplayWindow::LockCursor()
 {
-    ShowCursor(false);
     m_LockedPointer = backend->m_PointerConstraints.lock_pointer(m_AppSurface, backend->m_waylandPointer, nullptr, wayland::zwp_pointer_constraints_v1_lifetime::persistent);
     backend->SetMouseLocked(true);
+    ShowCursor(false);
 }
 
 void WaylandDisplayWindow::UnlockCursor()
 {
     if (m_LockedPointer)
         m_LockedPointer.proxy_release();
-    ShowCursor(true);
     backend->SetMouseLocked(false);
+    ShowCursor(true);
 }
 
 void WaylandDisplayWindow::CaptureMouse()
 {
-    backend->SetMouseLocked(true);
+    m_ConfinedPointer = backend->m_PointerConstraints.confine_pointer(GetWindowSurface(), backend->m_waylandPointer, nullptr, wayland::zwp_pointer_constraints_v1_lifetime::persistent);
+    ShowCursor(false);
 }
 
 void WaylandDisplayWindow::ReleaseMouseCapture()
 {
-    backend->SetMouseLocked(false);
+    if (m_ConfinedPointer)
+        m_ConfinedPointer.proxy_release();
+    ShowCursor(true);
 }
 
 void WaylandDisplayWindow::Update()

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -185,6 +185,8 @@ void WaylandDisplayWindow::Activate()
     xdgActivationToken.commit();  // This will set our token string
 
     backend->m_XDGActivation.activate(tokenString, m_AppSurface);
+    backend->m_FocusWindow = this;
+    backend->m_MouseFocusWindow = this;
     windowHost->OnWindowActivated();
 }
 
@@ -197,6 +199,7 @@ void WaylandDisplayWindow::LockCursor()
 {
     m_LockedPointer = backend->m_PointerConstraints.lock_pointer(m_AppSurface, backend->m_waylandPointer, nullptr, wayland::zwp_pointer_constraints_v1_lifetime::persistent);
     ShowCursor(false);
+    backend->SetMouseLocked(true);
 }
 
 void WaylandDisplayWindow::UnlockCursor()
@@ -204,6 +207,7 @@ void WaylandDisplayWindow::UnlockCursor()
     if (m_LockedPointer)
         m_LockedPointer.proxy_release();
     ShowCursor(true);
+    backend->SetMouseLocked(false);
 }
 
 void WaylandDisplayWindow::CaptureMouse()

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -76,6 +76,11 @@ void WaylandDisplayWindow::InitializeToplevel()
         OnExitEvent();
     };
 
+    m_XDGToplevel.on_configure_bounds() = [this] (int32_t width, int32_t height)
+    {
+
+    };
+
     m_XDGExported = backend->m_XDGExporter.export_toplevel(m_AppSurface);
 
     m_XDGExported.on_handle() = [&] (std::string handleStr) {
@@ -99,6 +104,8 @@ void WaylandDisplayWindow::InitializePopup()
     m_XDGPopup.on_configure() = [&] (int32_t x, int32_t y, int32_t width, int32_t height) {
         SetClientFrame(Rect::xywh(x, y, width, height));
     };
+
+    //m_XDGPopup.on_repositioned()
 
     m_XDGPopup.on_popup_done() = [&] () {
         OnExitEvent();
@@ -328,11 +335,11 @@ void WaylandDisplayWindow::OnExitEvent()
 
 void WaylandDisplayWindow::DrawSurface(uint32_t serial)
 {
+    m_AppSurface.attach(m_AppSurfaceBuffer, 0, 0);
+    m_AppSurface.damage(0, 0, m_WindowSize.width, m_WindowSize.height);
+
     if (m_renderAPI == RenderAPI::Unspecified || m_renderAPI == RenderAPI::Bitmap)
     {
-        m_AppSurface.attach(m_AppSurfaceBuffer, 0, 0);
-        m_AppSurface.damage(0, 0, m_WindowSize.width, m_WindowSize.height);
-
         m_FrameCallback = m_AppSurface.frame();
 
         m_FrameCallback.on_done() = bind_mem_fn(&WaylandDisplayWindow::DrawSurface, this);

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -197,8 +197,8 @@ void WaylandDisplayWindow::ShowCursor(bool enable)
 
 void WaylandDisplayWindow::LockCursor()
 {
-    m_LockedPointer = backend->m_PointerConstraints.lock_pointer(m_AppSurface, backend->m_waylandPointer, nullptr, wayland::zwp_pointer_constraints_v1_lifetime::persistent);
     ShowCursor(false);
+    m_LockedPointer = backend->m_PointerConstraints.lock_pointer(m_AppSurface, backend->m_waylandPointer, nullptr, wayland::zwp_pointer_constraints_v1_lifetime::persistent);
     backend->SetMouseLocked(true);
 }
 
@@ -212,12 +212,12 @@ void WaylandDisplayWindow::UnlockCursor()
 
 void WaylandDisplayWindow::CaptureMouse()
 {
-
+    backend->SetMouseLocked(true);
 }
 
 void WaylandDisplayWindow::ReleaseMouseCapture()
 {
-
+    backend->SetMouseLocked(false);
 }
 
 void WaylandDisplayWindow::Update()

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -335,6 +335,9 @@ void WaylandDisplayWindow::DrawSurface(uint32_t serial)
 
 void WaylandDisplayWindow::CreateBuffers(int32_t width, int32_t height)
 {
+    if (width == 0 || height == 0)
+        return;
+
     if (shared_mem)
         shared_mem.reset();
 

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -173,6 +173,7 @@ private:
     wayland::zxdg_exported_v2_t m_XDGExported;
 
     wayland::zwp_locked_pointer_v1_t m_LockedPointer;
+    wayland::zwp_confined_pointer_v1_t m_ConfinedPointer;
 
     wayland::callback_t m_FrameCallback;
 

--- a/bugs.txt
+++ b/bugs.txt
@@ -32,12 +32,12 @@ they end up dying because SE thinks that they've fallen from a great height.
 * There are no OpenGL and D3D renderers.
 * There is no networking support at all.
 * By design, native mods will never work with SE. Thankfully these kind of mods are extremely rare.
-* [Linux/ZWidget] Wayland backend is extremely buggy due to Wayland APIs being unpleasant to work with, to name a few things:
+* [Linux/ZWidget] Wayland backend is somewhat buggy due to Wayland APIs being unpleasant to work with, to name a few things:
  - Menus don't properly position themselves.
- - Sometimes menus remain persistent (due to rapidly switching?), if the user then tries to resize the parent window, it causes a crash.
+ - Sometimes menus remain persistent (due to rapidly switching?)
  - Running any ZWidget app (launcher/SurrealEditor) on GNOME will probably lead to not being able to move the window around, 
  because ZWidget has no custom window decorations (ZWidget uses server side decorations when they're available)
- - SurrealEngine produces a black screen that is not interactable in any way, while SurrealEditor crashes when trying to open a map
+ - SurrealEditor crashes when trying to open a map
 
 Engine general - Needs testing:
 -------------------------------


### PR DESCRIPTION
* SurrealEngine now shows the game properly on the Wayland backend, and keyboard and mouse input works.
* SurrealEditor opens up, the viewports move properly, but loading a map still crashes it.
* Fixed the crash when trying to unmaximize a window that initially opened up maximized.

This PR also allows SurrealEngine to use `ZWIDGET_DISPLAY_BACKEND` again, as I think the Wayland backend is usable enough to run the game itself now.