### PR TITLE
Implement "set input" console command

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -772,6 +772,14 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 		NameString propertyName = args[2];
 		std::string value = args[3];
 
+		// Special input setting handling
+		if (className == "input")
+		{
+			keybindings[propertyName.ToString()] = value;
+			packages->SetIniValue("user", "Engine.Input", propertyName, value);
+			return {};
+		}
+
 		UClass* cls = packages->FindClass(className);
 		if (!cls)
 		{

--- a/SurrealEngine/UObject/UClass.cpp
+++ b/SurrealEngine/UObject/UClass.cpp
@@ -636,7 +636,7 @@ void UClass::SaveToConfig(PackageManager& packageManager)
 	// Iterate and save Properties that are marked with Config
 	for (UProperty* prop : PropertyData.Class->Properties)
 	{
-		if ((uint32_t)(prop->PropFlags & PropertyFlags::Config))
+		if (AnyFlags(prop->PropFlags, PropertyFlags::Config | PropertyFlags::GlobalConfig))
 		{
 			ini_file->SetValue(this->Name, prop->Name, prop->PrintValue(PropertyData.Ptr(prop)));
 		}


### PR DESCRIPTION
This should fix #144 

Tested with setting the left arrow key to turn left. The new setting both got applied immediately and persisted after restarting the game.