### PR TITLE
Widget/Window: Add fullscreen mode checks

### DIFF
--- a/SurrealEngine/GameWindow.cpp
+++ b/SurrealEngine/GameWindow.cpp
@@ -39,6 +39,35 @@ int GameWindow::GetPixelHeight()
 	return GetNativePixelHeight();
 }
 
+void GameWindow::ToggleWindowFullscreen(Size newResolution)
+{
+	if (this->IsFullscreen())
+	{
+		// First switch to normal
+		this->ShowNormal();
+
+		// Then resize the window
+		auto geometry = this->GetFrameGeometry();
+		geometry.width = newResolution.width;
+		geometry.height = newResolution.height;
+		this->SetFrameGeometry(geometry);
+	}
+	else
+	{
+		// Get the nearest valid fullscreen resolution first
+		auto selectedResolution = GetClosestResolution(newResolution);
+
+		// Then resize the window to the resolution
+		auto geometry = this->GetFrameGeometry();
+		geometry.width = selectedResolution.width;
+		geometry.height = selectedResolution.height;
+		this->SetFrameGeometry(geometry);
+
+		// Finally switch to fullscreen
+		this->ShowFullscreen();
+	}
+}
+
 bool GameWindow::GetKeyState(EInputKey key)
 {
 	return Widget::GetKeyState((InputKey)key);
@@ -248,7 +277,7 @@ void GameWindow::SetResolution(const std::string& resolutionString)
 
 	Rect windowRect = GetFrameGeometry();
 
-	if (isWindowFullscreen)
+	if (IsFullscreen())
 	{
 		parsedResolution = GetClosestResolution(parsedResolution);
 		windowRect.x = 0;

--- a/SurrealEngine/GameWindow.h
+++ b/SurrealEngine/GameWindow.h
@@ -124,6 +124,8 @@ public:
 	int GetPixelWidth();
 	int GetPixelHeight();
 
+	void ToggleWindowFullscreen(Size newResolution);
+
 	std::string GetAvailableResolutions() const;
 	void SetResolution(const std::string& resolutionString);
 
@@ -148,8 +150,6 @@ private:
 	void AddResolutionIfNotAdded(Array<Size>& resList, Size resolution) const;
 	Size ParseResolutionString(const std::string& resolutionString) const;
 	Size GetClosestResolution(Size resolution) const;
-
-	bool isWindowFullscreen = false;
 
 	GameWindowHost* windowHost = nullptr;
 	std::unique_ptr<RenderDevice> device;

--- a/Thirdparty/ZWidget/include/zwidget/core/widget.h
+++ b/Thirdparty/ZWidget/include/zwidget/core/widget.h
@@ -88,6 +88,7 @@ public:
 	void SetVisible(bool enable) { if (enable) Show(); else Hide(); }
 	void Show();
 	void ShowFullscreen();
+	bool IsFullscreen();
 	void ShowMaximized();
 	void ShowMinimized();
 	void ShowNormal();

--- a/Thirdparty/ZWidget/include/zwidget/window/window.h
+++ b/Thirdparty/ZWidget/include/zwidget/window/window.h
@@ -155,6 +155,7 @@ public:
 	virtual void ShowMaximized() = 0;
 	virtual void ShowMinimized() = 0;
 	virtual void ShowNormal() = 0;
+	virtual bool IsWindowFullscreen() = 0;
 	virtual void Hide() = 0;
 	virtual void Activate() = 0;
 	virtual void ShowCursor(bool enable) = 0;

--- a/Thirdparty/ZWidget/src/core/widget.cpp
+++ b/Thirdparty/ZWidget/src/core/widget.cpp
@@ -218,6 +218,16 @@ void Widget::ShowFullscreen()
 	}
 }
 
+bool Widget::IsFullscreen()
+{
+	if (Type != WidgetType::Child)
+	{
+		return DispWindow->IsWindowFullscreen();
+	}
+
+	return false;
+}
+
 void Widget::ShowMaximized()
 {
 	if (Type != WidgetType::Child)

--- a/Thirdparty/ZWidget/src/window/sdl2/sdl2_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/sdl2/sdl2_display_window.cpp
@@ -108,6 +108,7 @@ void SDL2DisplayWindow::ShowFullscreen()
 {
 	SDL_ShowWindow(Handle.window);
 	SDL_SetWindowFullscreen(Handle.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+	isFullscreen = true;
 }
 
 void SDL2DisplayWindow::ShowMaximized()
@@ -126,6 +127,12 @@ void SDL2DisplayWindow::ShowNormal()
 {
 	SDL_ShowWindow(Handle.window);
 	SDL_SetWindowFullscreen(Handle.window, 0);
+	isFullscreen = false;
+}
+
+bool SDL2DisplayWindow::IsWindowFullscreen()
+{
+	return isFullscreen;
 }
 
 void SDL2DisplayWindow::Hide()

--- a/Thirdparty/ZWidget/src/window/sdl2/sdl2_display_window.h
+++ b/Thirdparty/ZWidget/src/window/sdl2/sdl2_display_window.h
@@ -20,7 +20,7 @@ public:
 	void ShowMaximized() override;
 	void ShowMinimized() override;
 	void ShowNormal() override;
-	void IsWindowFullscreen() override;
+	bool IsWindowFullscreen() override;
 	void Hide() override;
 	void Activate() override;
 	void ShowCursor(bool enable) override;

--- a/Thirdparty/ZWidget/src/window/sdl2/sdl2_display_window.h
+++ b/Thirdparty/ZWidget/src/window/sdl2/sdl2_display_window.h
@@ -20,6 +20,7 @@ public:
 	void ShowMaximized() override;
 	void ShowMinimized() override;
 	void ShowNormal() override;
+	void IsWindowFullscreen() override;
 	void Hide() override;
 	void Activate() override;
 	void ShowCursor(bool enable) override;
@@ -96,4 +97,6 @@ public:
 	static bool ExitRunLoop;
 	static Uint32 PaintEventNumber;
 	static std::unordered_map<int, SDL2DisplayWindow*> WindowList;
+
+	bool isFullscreen = false;
 };

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -147,7 +147,11 @@ void WaylandDisplayWindow::Show()
 void WaylandDisplayWindow::ShowFullscreen()
 {
     if (m_XDGToplevel)
+    {
         m_XDGToplevel.set_fullscreen(backend->m_waylandOutput);
+        isFullscreen = true;
+    }
+        
 }
 
 void WaylandDisplayWindow::ShowMaximized()
@@ -165,7 +169,10 @@ void WaylandDisplayWindow::ShowMinimized()
 void WaylandDisplayWindow::ShowNormal()
 {
     if (m_XDGToplevel)
+    {
         m_XDGToplevel.unset_fullscreen();
+        isFullscreen = true;
+    }
 }
 
 void WaylandDisplayWindow::Hide()

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -154,6 +154,11 @@ void WaylandDisplayWindow::ShowFullscreen()
         
 }
 
+bool WaylandDisplayWindow::IsWindowFullscreen()
+{
+    return isFullscreen;
+}
+
 void WaylandDisplayWindow::ShowMaximized()
 {
     if (m_XDGToplevel)

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -96,6 +96,7 @@ public:
 	void ShowMaximized() override;
 	void ShowMinimized() override;
 	void ShowNormal() override;
+    bool IsWindowFullscreen() override;
 	void Hide() override;
 	void Activate() override;
 	void ShowCursor(bool enable) override;
@@ -181,6 +182,8 @@ private:
     std::string m_ClipboardContents;
 
     std::shared_ptr<SharedMemHelper> shared_mem;
+
+    bool isFullscreen;
 
     // Helper functions
     void CreateBuffers(int32_t width, int32_t height);

--- a/Thirdparty/ZWidget/src/window/win32/win32_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/win32/win32_display_window.cpp
@@ -148,6 +148,12 @@ void Win32DisplayWindow::ShowMinimized()
 void Win32DisplayWindow::ShowNormal()
 {
 	ShowWindow(WindowHandle.hwnd, SW_NORMAL);
+	Fullscreen = false;
+}
+
+bool Win32DisplayWindow::IsWindowFullscreen()
+{
+	return Fullscreen;
 }
 
 void Win32DisplayWindow::Hide()

--- a/Thirdparty/ZWidget/src/window/win32/win32_display_window.h
+++ b/Thirdparty/ZWidget/src/window/win32/win32_display_window.h
@@ -21,6 +21,7 @@ public:
 	void ShowMaximized() override;
 	void ShowMinimized() override;
 	void ShowNormal() override;
+	bool IsWindowFullscreen() override;
 	void Hide() override;
 	void Activate() override;
 	void ShowCursor(bool enable) override;

--- a/Thirdparty/ZWidget/src/window/x11/x11_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/x11/x11_display_window.cpp
@@ -234,6 +234,11 @@ void X11DisplayWindow::ShowFullscreen()
 	}
 }
 
+bool X11DisplayWindow::IsWindowFullscreen()
+{
+	return isFullscreen;
+}
+
 void X11DisplayWindow::ShowMaximized()
 {
 	Show();

--- a/Thirdparty/ZWidget/src/window/x11/x11_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/x11/x11_display_window.cpp
@@ -230,6 +230,7 @@ void X11DisplayWindow::ShowFullscreen()
 	{
 		Atom state = GetAtom("_NET_WM_STATE_FULLSCREEN");
 		XChangeProperty(display, window, GetAtom("_NET_WM_STATE"), XA_ATOM, 32, PropModeReplace, (unsigned char *)&state, 1);
+		isFullscreen = true;
 	}
 }
 
@@ -251,6 +252,7 @@ void X11DisplayWindow::ShowMinimized()
 void X11DisplayWindow::ShowNormal()
 {
 	Show();
+	isFullscreen = false;
 }
 
 void X11DisplayWindow::Hide()

--- a/Thirdparty/ZWidget/src/window/x11/x11_display_window.h
+++ b/Thirdparty/ZWidget/src/window/x11/x11_display_window.h
@@ -128,5 +128,7 @@ private:
 
 	bool needsUpdate = false;
 
+	bool isFullscreen = false;
+
 	friend class X11DisplayBackend;
 };

--- a/Thirdparty/ZWidget/src/window/x11/x11_display_window.h
+++ b/Thirdparty/ZWidget/src/window/x11/x11_display_window.h
@@ -23,6 +23,7 @@ public:
 	void ShowMaximized() override;
 	void ShowMinimized() override;
 	void ShowNormal() override;
+	bool IsWindowFullscreen() override;
 	void Hide() override;
 	void Activate() override;
 	void ShowCursor(bool enable) override;


### PR DESCRIPTION
GameWindow::isWindowFullscreen variable was never used, nor set anywhere. Moved this variable to window classes, where it belongs, as well as added functions to check for the said variable in all Window classes.

This will allow us to implement "togglefullscreen" engine command.