### PR TITLE
Implement "togglefullscreen" command

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -820,6 +820,22 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 	{
 		window->SetResolution(args[1]);
 	}
+	else if (command == "togglefullscreen")
+	{
+		bool isFullscreen = window->IsFullscreen();
+
+		// Get the resolutions to SWITCH TO
+		int width = isFullscreen ? client->WindowedViewportX : client->FullscreenViewportX;
+		int height = isFullscreen ? client->WindowedViewportY : client->FullscreenViewportY;
+
+		Size resolution;
+		resolution.width = width;
+		resolution.height = height;
+
+		window->ToggleWindowFullscreen(resolution);
+
+		return {};
+	}
 	else
 	{
 		if (!ExecCommand(args))


### PR DESCRIPTION
Follow-up to #153 

This one will implement the aforementioned command, making this button down below work.

![image](https://github.com/user-attachments/assets/01cdd621-2633-4f13-acb3-381c7965f1ae)

On Windows, this will result in a window without any decorations when switching from fullscreen. Not sure why.
