### PR TITLE
Add Fedora Linux instructions and fix Linux build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Note that these packages won't always have the exact names given above, as it ca
 **Arch Linux**
 
     # pacman -S libx11 gcc git cmake sdl2 alsa-lib waylandpp
+    
+**Fedora**
+
+    # dnf install libX11 libX11-devel libxkbcommon libxkbcommon-devel SDL2-devel openal-soft-devel alsa-lib-devel waylandpp waylandpp-devel
 
 #### After installing prerequisites
 

--- a/Thirdparty/ZWidget/CMakeLists.txt
+++ b/Thirdparty/ZWidget/CMakeLists.txt
@@ -3,7 +3,10 @@ project(zwidget)
 
 if (UNIX AND NOT APPLE)
 	include(FindPkgConfig)
-	pkg_check_modules(DBUS REQUIRED dbus-1)
+	pkg_check_modules(DBUS dbus-1)
+	if (!DBUS_FOUND)
+		pkg_check_modules(DBUS REQUIRED dbus) # Fedora Linux looks for dbus instead
+	endif()
 	pkg_check_modules(WAYLANDPP
 		wayland-client
 		wayland-client++

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.cpp
@@ -1,6 +1,7 @@
 #include "wayland_display_window.h"
 
 #include <cstring>
+#include <dlfcn.h>
 
 
 WaylandDisplayWindow::WaylandDisplayWindow(WaylandDisplayBackend* backend, DisplayWindowHost* windowHost, bool popupWindow, WaylandDisplayWindow* owner, RenderAPI renderAPI)

--- a/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
+++ b/Thirdparty/ZWidget/src/window/wayland/wayland_display_window.h
@@ -132,6 +132,8 @@ public:
 
 	wayland::surface_t GetWindowSurface() { return m_AppSurface; }
 
+	bool IsWindowFullscreen() override;
+
 private:
     // Event handlers as otherwise linking DisplayWindowHost On...() functions with Wayland events directly crashes the app
     // Alternatively to avoid crashes one can capture by value ([=]) instead of reference ([&])


### PR DESCRIPTION
* Added Fedora Linux instructions to the prerequisite packages section
* Made ZWidget buildable on Fedora Linux (It needs dbus there, instead of dbus-1)
* Fixed some compliation errors of WaylandDisplayWindow (missing include and virtual function override)