### PR TITLE
Persisting Input settings + FOV

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -480,6 +480,8 @@ void Engine::LoginPlayer()
 		Exception::Throw("GameInfo login failed: " + error);
 	bool actorActuallySpawned = Level->Actors.size() != numActors;
 
+	pawn->LoadProperties();
+
 	// Assign the pawn to the viewport
 	viewport->Actor() = pawn;
 	viewport->Actor()->Player() = viewport;

--- a/SurrealEngine/Package/IniFile.h
+++ b/SurrealEngine/Package/IniFile.h
@@ -46,10 +46,14 @@ public:
 	bool SetValue(const NameString& keyName, const std::string& newValue, const int index = 0, const bool indexed = false);
 	bool SetValues(const NameString& keyName, const Array<std::string>& newValues, const bool indexed = false);
 
+	bool HasNewKey() const { return hasNewKey; }
+	void SetHasNewKey(bool value) { hasNewKey = value; }
+
 private:
 	std::string name;
 	uint32_t hash;
 	Array<IniKey> keys;
+	bool hasNewKey = false; // True when SetValue[s]() adds a new key to the Section.
 };
 
 class IniFile
@@ -90,6 +94,7 @@ private:
 	const IniSection* FindSection(const std::string& sectionName) const;
 
 	bool isModified = false;
+	bool hasNewKeys = false; // True if any of the IniSection.hasNewKey values are true. If this is true, then the IniFile must be written to the disk from scratch.
 	std::string ini_file_path;
 	Array<IniSection> sections;
 };

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -7,6 +7,7 @@
 #include "VM/ScriptCall.h"
 #include "VM/Frame.h"
 #include "Package/PackageManager.h"
+#include "Package/IniProperty.h"
 #include "Engine.h"
 #include "Collision/TraceAABBModel.h"
 #include "Collision/TraceRayModel.h"
@@ -2457,6 +2458,59 @@ void UPlayerPawn::TickRotating(float elapsed)
 	// To do: apply RotationRate().Roll
 
 	Rotation() = rot;
+}
+
+void UPlayerPawn::LoadProperties()
+{
+	bInvertMouse() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bInvertMouse", true);
+	MouseSensitivity() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "MouseSensitivity", 5.0f);
+	// TODO: Handle the array property this class has (WeaponPriority)
+	DodgeClickTime() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "DodgeClickTime", 0.25f);
+	Bob() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "Bob", 0.016f);
+	MyAutoAim() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "MyAutoAim", 1.0f);
+	Handedness() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "Handedness", -1.0f);
+	bLookUpStairs() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bLookUpStairs", false);
+	bSnapToLevel() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bSnapToLevel", false);
+	bAlwaysMouseLook() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bAlwaysMouseLook", true);
+	bKeyboardLook() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bKeyboardLook", false);
+	bMaxMouseSmoothing() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bMaxMouseSmoothing", false);
+	bNoFlash() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bNoFlash", false);
+	bNoVoices() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bNoVoices", false);
+	bMessageBeep() = IniPropertyConverter<bool>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "bMessageBeep", true);
+	// NetSpeed is missing
+	// LanSpeed is missing
+	MouseSmoothThreshold() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "MouseSmoothThreshold", 0.16f);
+	ngWorldSecret() = IniPropertyConverter<std::string>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "ngWorldSecret", "");
+
+	// SE addition: Store/Load the DefaultFOV setting into/from the user.ini file as well
+	DefaultFOV() = IniPropertyConverter<float>::FromIniFile(*engine->packages->GetIniFile("user"), "Engine.PlayerPawn", "MainFOV", 90.0f);
+}
+
+void UPlayerPawn::SaveConfig()
+{
+	// Not sure why are PlayerPawn's config fields not saved with the base SaveConfig(), but whatever. 
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bInvertMouse", IniPropertyConverter<bool>::ToString(bInvertMouse()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "MouseSensitivity", IniPropertyConverter<float>::ToString(MouseSensitivity()));
+	// TODO: Handle the array property this class has (WeaponPriority)
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "DodgeClickTime", IniPropertyConverter<float>::ToString(DodgeClickTime()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "Bob", IniPropertyConverter<float>::ToString(Bob()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "MyAutoAim", IniPropertyConverter<float>::ToString(MyAutoAim()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "Handedness", IniPropertyConverter<float>::ToString(Handedness()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bLookUpStairs", IniPropertyConverter<bool>::ToString(bLookUpStairs()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bSnapToLevel", IniPropertyConverter<bool>::ToString(bSnapToLevel()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bAlwaysMouseLook", IniPropertyConverter<bool>::ToString(bAlwaysMouseLook()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bKeyboardLook", IniPropertyConverter<bool>::ToString(bKeyboardLook()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bMaxMouseSmoothing", IniPropertyConverter<bool>::ToString(bMaxMouseSmoothing()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bNoFlash", IniPropertyConverter<bool>::ToString(bNoFlash()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bNoVoices", IniPropertyConverter<bool>::ToString(bNoVoices()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "bMessageBeep", IniPropertyConverter<bool>::ToString(bMessageBeep()));
+	// NetSpeed is missing
+	// LanSpeed is missing
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "MouseSmoothThreshold", IniPropertyConverter<float>::ToString(MouseSmoothThreshold()));
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "ngWorldSecret", ngWorldSecret());
+
+	// SE addition: Store/Load the DefaultFOV setting into/from the user.ini file as well
+	engine->packages->SetIniValue("user", "Engine.PlayerPawn", "MainFOV", IniPropertyConverter<float>::ToString(DefaultFOV()));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -1715,6 +1715,9 @@ public:
 	float& shaketimer() { return Value<float>(PropOffsets_PlayerPawn.shaketimer); }
 	float& shakevert() { return Value<float>(PropOffsets_PlayerPawn.shakevert); }
 	float& verttimer() { return Value<float>(PropOffsets_PlayerPawn.verttimer); }
+
+	void LoadProperties(); // Always loaded from User.ini
+	void SaveConfig() override;
 };
 
 class UCamera : public UPlayerPawn


### PR DESCRIPTION
These changes make the settings in the Input tab (like "Invert Mouse" and such) persist across map changes and game reloads, as well as the changes made by the `fov` command.

For the latter, the IniFile class now recreates the entire ini file if there is a new key added to any sections. This isn't exactly ideal, as it can cause the other data put inside the ini files (like comments) to be removed, but this should be enough for the time being.
