### PR TITLE
Move map case sensitivity workaround to PackageManager::LoadMap()

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -230,8 +230,6 @@ void Engine::Run()
 	packages->SetIniValue("System", "Engine.SurrealWindowSystem", "WindowSystem", windowingSystemName);
 	packages->SaveAllIniFiles();
 
-	//audiodev->ShutdownDevice();
-
 	CloseWindow();
 }
 
@@ -722,7 +720,6 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 
 			if (StrCompare::equals_ignore_case(mapname, url.Map))
 			{
-				url.Map = mapname; // Workaround against case sensitivity problems under Linux
 				LoadMap(url);
 				LoginPlayer();
 				return {};
@@ -830,7 +827,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 	{
 		bool isFullscreen = window->IsFullscreen();
 
-		// Get the resolutions to SWITCH TO
+		// Get the resolution to SWITCH TO
 		int width = isFullscreen ? client->WindowedViewportX : client->FullscreenViewportX;
 		int height = isFullscreen ? client->WindowedViewportY : client->FullscreenViewportY;
 

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -5,6 +5,7 @@
 #include "PackageStream.h"
 #include "IniFile.h"
 #include "Utils/File.h"
+#include "Utils/StrCompare.h"
 #include "UObject/UObject.h"
 #include "UObject/UClass.h"
 #include "VM/NativeFunc.h"
@@ -77,6 +78,13 @@ std::unique_ptr<Package> PackageManager::LoadMap(const std::string& path)
 
 	if (!FilePath::has_extension(map, GetMapExtension().c_str()))
 		map += "." + GetMapExtension();
+
+	// Check if the map is in the map list
+	for (auto& mapName : maps)
+	{
+		if (StrCompare::equals_ignore_case(mapName, map))
+			map = mapName; // Workaround against case sensitivity problems under Linux
+	}
 
 	// Check the map name against the map folders we know
 	for (auto& folder : mapFolders)


### PR DESCRIPTION
So that map transitions work under Linux too