### PR TITLE
More small fixes

### DIFF
--- a/Thirdparty/ZVulkan/src/glslang/spirv/SpvBuilder.h
+++ b/Thirdparty/ZVulkan/src/glslang/spirv/SpvBuilder.h
@@ -63,6 +63,7 @@ namespace spv {
 #include <stack>
 #include <unordered_map>
 #include <map>
+#include <cstdint>
 
 namespace spv {
 

--- a/Thirdparty/ZWidget/CMakeLists.txt
+++ b/Thirdparty/ZWidget/CMakeLists.txt
@@ -229,6 +229,7 @@ else()
 	set(ZWIDGET_DEFINES -DUNIX -D_UNIX -DUSE_SDL2 -DUSE_X11)
 	set(ZWIDGET_LINK_OPTIONS -pthread)
 	if (DBUS_FOUND)
+		include_directories("/usr/lib64/dbus-1.0/include") # Bazzite (and probably Fedora 42) keeps the platform-specific dbus headers in this folder
 		set(ZWIDGET_SOURCES ${ZWIDGET_SOURCES} ${ZWIDGET_DBUS_SOURCES})
 		set(ZWIDGET_INCLUDE_DIRS ${ZWIDGET_INCLUDE_DIRS} ${DBUS_INCLUDE_DIRS})
 		set(ZWIDGET_LIBS ${ZWIDGET_LIBS} ${DBUS_LDFLAGS})


### PR DESCRIPTION
* Added a missing include in ZVulkan's SpvBuilder.h
* Added an additional include folder in ZWidget's CMakeLists.txt. For some reason (perhaps a Fedora/Bazzite thing) some platform specific headers were inside another folder, which CMake couldn't find at all. With this change (and lots of `rpm-ostree` usage), I managed to build SurrealEngine on Bazzite.