### PR TITLE
SurrealEditor: Colorize 2D viewport lines

### DIFF
--- a/SurrealEngine/UI/Editor/Editor2DViewport.h
+++ b/SurrealEngine/UI/Editor/Editor2DViewport.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "EditorViewport.h"
+#include "UObject/UActor.h"
 #include "Math/rotator.h"
 #include "Math/coords.h"
 
@@ -27,8 +28,20 @@ private:
 	void DrawGrid(Canvas* canvas);
 	void MoveCamera(float x, float y);
 
+	void ReadLineColors();
+
+	Colorf GetActorLineColor(UActor* actor) const;
+
 	bool MouseIsMoving = false;
 	vec2 Location = vec2(0.0f);
 	double Zoom = 0.05;
 	Coords ViewCoords = Coords::Identity();
+
+	Colorf m_BrushWireColor;
+	Colorf m_BrushAddColor;
+	Colorf m_BrushSubColor;
+	Colorf m_SemiSolidWireColor;
+	Colorf m_NonSolidWireColor;
+	Colorf m_ActorWireColor;
+	Colorf m_MoverColor;
 };

--- a/SurrealEngine/UObject/UObject.h
+++ b/SurrealEngine/UObject/UObject.h
@@ -52,6 +52,15 @@ enum UnrealUPropertyStruct
 	UPS_PointRegion
 };
 
+enum CSGOper
+{
+	CSG_Active,
+	CSG_Add,
+	CSG_Sub,
+	CSG_Intersect,
+	CSG_Deintersect
+};
+
 struct PropertyHeader
 {
 	UnrealPropertyType type;


### PR DESCRIPTION
These colors are stored in `Editor.EditorEngine` section of the system ini file. This PR reads some of these colors (only the ones we can use right now), and uses them to colorize the brush lines.

<img width="944" height="472" alt="A screenshot from SurrealEditor showing DmTundra, map's brushes are colorized in a way that is appropriate for them" src="https://github.com/user-attachments/assets/e9647271-8c10-468e-aad4-15ef96d06220" />
