### PR TITLE
Switch to C++20 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,20 +553,20 @@ if(MSVC)
 endif()
 
 add_library(SurrealCommon STATIC ${SURREALCOMMON_SOURCES} ${THIRDPARTY_SOURCES})
-set_target_properties(SurrealCommon PROPERTIES CXX_STANDARD 17)
+set_target_properties(SurrealCommon PROPERTIES CXX_STANDARD 20)
 target_precompile_headers(SurrealCommon PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/SurrealEngine/Precomp.h>)
 
 add_executable(SurrealEngine WIN32 MACOSX_BUNDLE ${SURREALENGINE_SOURCES})
 target_link_libraries(SurrealEngine SurrealCommon ${SURREALCOMMON_LIBS})
-set_target_properties(SurrealEngine PROPERTIES CXX_STANDARD 17)
+set_target_properties(SurrealEngine PROPERTIES CXX_STANDARD 20)
 
 add_executable(SurrealEditor WIN32 MACOSX_BUNDLE ${SURREALEDITOR_SOURCES})
 target_link_libraries(SurrealEditor SurrealCommon ${SURREALCOMMON_LIBS})
-set_target_properties(SurrealEditor PROPERTIES CXX_STANDARD 17)
+set_target_properties(SurrealEditor PROPERTIES CXX_STANDARD 20)
 
 add_executable(SurrealDebugger ${SURREALDEBUGGER_SOURCES})
 target_link_libraries(SurrealDebugger SurrealCommon ${SURREALCOMMON_LIBS})
-set_target_properties(SurrealDebugger PROPERTIES CXX_STANDARD 17)
+set_target_properties(SurrealDebugger PROPERTIES CXX_STANDARD 20)
 
 if(WIN32)
 add_custom_command(TARGET SurrealEngine POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:OpenAL::OpenAL>" $<TARGET_FILE_DIR:SurrealEngine>)

--- a/Thirdparty/ZVulkan/CMakeLists.txt
+++ b/Thirdparty/ZVulkan/CMakeLists.txt
@@ -208,7 +208,7 @@ endif()
 
 add_library(zvulkan STATIC ${ZVULKAN_SOURCES} ${ZVULKAN_INCLUDES} ${VULKAN_INCLUDES})
 target_link_libraries(zvulkan ${ZVULKAN_LIBS})
-set_target_properties(zvulkan PROPERTIES CXX_STANDARD 17)
+set_target_properties(zvulkan PROPERTIES CXX_STANDARD 20)
 
 #if(MSVC)
 #	set_property(TARGET zvulkan PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/Thirdparty/ZWidget/CMakeLists.txt
+++ b/Thirdparty/ZWidget/CMakeLists.txt
@@ -263,7 +263,7 @@ target_compile_definitions(zwidget PRIVATE ${ZWIDGET_DEFINES})
 target_include_directories(zwidget PRIVATE ${ZWIDGET_INCLUDE_DIRS})
 target_link_options(zwidget PRIVATE ${ZWIDGET_LINK_OPTIONS})
 target_link_libraries(zwidget ${ZWIDGET_LIBS})
-set_target_properties(zwidget PROPERTIES CXX_STANDARD 17)
+set_target_properties(zwidget PROPERTIES CXX_STANDARD 20)
 
 #if(MSVC)
 #	set_property(TARGET zwidget PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
Previous PR had used designated initializers in one place, which I forgot that was a C++20 feature.

There doesn't seem to be any harm in switching the entire project to use the newer standard, so let's do so.