### PR TITLE
Don't render invisible polys in-game

### DIFF
--- a/SurrealEngine/EditorApp.cpp
+++ b/SurrealEngine/EditorApp.cpp
@@ -26,6 +26,7 @@ int EditorApp::main(Array<std::string> args)
 		if (!info.gameRootFolder.empty())
 		{
 			Engine engine(info);
+			engine.setEditorMode(true);
 
 			auto editorWindow = std::make_unique<EditorMainWindow>();
 			editorWindow->SetFrameGeometry(Rect::xywh(0.0, 0.0, 1024.0, 768.0));

--- a/SurrealEngine/Engine.h
+++ b/SurrealEngine/Engine.h
@@ -183,6 +183,11 @@ public:
 	std::map<std::string, ActiveInputAxis> activeInputAxes;
 
 	std::function<void()> tickDebugger;
+
+	bool getEditorMode() const { return m_EditorMode; }
+	void setEditorMode(const bool value) { m_EditorMode = value; }
+private:
+	bool m_EditorMode = false; // Set this to true to allow rendering of invisible polys.
 };
 
 extern Engine* engine;

--- a/SurrealEngine/Render/RenderBrush.cpp
+++ b/SurrealEngine/Render/RenderBrush.cpp
@@ -36,6 +36,9 @@ void RenderSubsystem::DrawBrushPoly(FSceneNode* frame, UModel* model, const Poly
 {
 	uint32_t PolyFlags = poly.PolyFlags;
 
+	if (!engine->getEditorMode() && PolyFlags & PolyFlags::PF_Invisible)
+		return;
+
 	//UpdateTexture(poly.Texture);
 
 	auto zoneActor = actor->Region().Zone;


### PR DESCRIPTION
This PR adds a "editor mode" flag to Engine class, and then makes DrawBrushPoly() function render invisible polys ONLY when the Engine is in said editor mode.

It can be improved more when Surreal Editor gets a real time preview mode just like UnrealEd does, but this is a good start.

In Surreal Editor:
<img width="942" height="454" alt="Vortex Rikers' Kevlar Suit room, in Surreal Editor. Invisible polys get rendered." src="https://github.com/user-attachments/assets/83121c78-82ac-440a-b89d-22299dad57b8" />

In game:
<img width="1920" height="1080" alt="Vortex Rikers' Kevlar Suit room, in Surreal Engine. Invisible polys do NOT get rendered." src="https://github.com/user-attachments/assets/39feeb48-ab55-4a9c-a2b7-e5734db93597" />
