### PR TITLE
Add ETravelType enum and use it wherever possible

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -163,7 +163,7 @@ void Engine::Run()
 		{
 			// To do: need to do something about that travel type and transfering of items
 
-			UnrealURL url(LevelInfo->URL, ClientTravelInfo.URL);
+			UnrealURL url(ClientTravelInfo.URL);
 
 			auto travelInfo = Level->TravelInfo;
 			for (UActor* actor : Level->Actors)
@@ -244,7 +244,16 @@ void Engine::UpdateAudio()
 
 void Engine::ClientTravel(const std::string& newURL, ETravelType travelType, bool transferItems)
 {
-	ClientTravelInfo.URL = UnrealURL(newURL);
+	if (travelType == ETravelType::TRAVEL_Absolute)
+		ClientTravelInfo.URL = UnrealURL(newURL);
+	else if (travelType == ETravelType::TRAVEL_Partial)
+	{
+		auto name = ClientTravelInfo.URL.GetOption("name");
+		ClientTravelInfo.URL = UnrealURL(newURL);
+		ClientTravelInfo.URL.AddOrReplaceOption("name=" + name);
+	}
+	else if (travelType == ETravelType::TRAVEL_Relative)
+		ClientTravelInfo.URL = UnrealURL(ClientTravelInfo.URL, newURL);
 	ClientTravelInfo.TravelType = travelType;
 	ClientTravelInfo.TransferItems = transferItems;
 }

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -242,7 +242,7 @@ void Engine::UpdateAudio()
 	audiodev->Update(listener);
 }
 
-void Engine::ClientTravel(const std::string& newURL, uint8_t travelType, bool transferItems)
+void Engine::ClientTravel(const std::string& newURL, ETravelType travelType, bool transferItems)
 {
 	ClientTravelInfo.URL = UnrealURL(newURL);
 	ClientTravelInfo.TravelType = travelType;

--- a/SurrealEngine/Engine.h
+++ b/SurrealEngine/Engine.h
@@ -6,7 +6,7 @@
 #include "Math/floating.h"
 #include "RenderDevice/RenderDevice.h"
 #include "GameWindow.h"
-#include "UObject/UObject.h"
+#include "UObject/UActor.h"
 #include "UObject/UnrealURL.h"
 #include "GameFolder.h"
 #include <set>
@@ -60,7 +60,7 @@ public:
 	~Engine();
 
 	void Run();
-	void ClientTravel(const std::string& URL, uint8_t travelType, bool transferItems);
+	void ClientTravel(const std::string& URL, ETravelType travelType, bool transferItems);
 	UnrealURL GetDefaultURL(const std::string& map);
 	void LoadEntryMap();
 	void LoadMap(const UnrealURL& url, const std::map<std::string, std::string>& travelInfo = {});
@@ -132,7 +132,7 @@ public:
 	struct
 	{
 		UnrealURL URL;
-		uint8_t TravelType = 0;
+		ETravelType TravelType = ETravelType::TRAVEL_Absolute;
 		bool TransferItems = false;
 	} ClientTravelInfo;
 

--- a/SurrealEngine/Native/NPlayerPawn.cpp
+++ b/SurrealEngine/Native/NPlayerPawn.cpp
@@ -22,7 +22,7 @@ void NPlayerPawn::RegisterFunctions()
 
 void NPlayerPawn::ClientTravel(UObject* Self, const std::string& URL, uint8_t TravelType, bool bItems)
 {
-	engine->ClientTravel(URL, TravelType, bItems);
+	engine->ClientTravel(URL, static_cast<ETravelType>(TravelType), bItems);
 }
 
 void NPlayerPawn::ConsoleCommand(UObject* Self, const std::string& Command, std::string& ReturnValue)

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -144,6 +144,13 @@ enum EDrawType
 	DT_SpriteAnimOnce
 };
 
+enum class ETravelType : uint8_t
+{
+	TRAVEL_Absolute, // Absolute URL
+	TRAVEL_Partial,  // Partial (Carry name, reset server)
+	TRAVEL_Relative  // Relative URL
+};
+
 class UActor : public UObject
 {
 public:


### PR DESCRIPTION
Engine::ClientTravel() now creates the new URL depending on `travelType`.

This fixes a bug where starting a Botmatch in Unreal then starting the campaign would result in Vortex Rikers starting in Botmatch mode.