### PR TITLE
Implement bSaveDefault option for UpdateURL(), and get Player Setup dialog working

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -1426,13 +1426,11 @@ void Engine::OnWindowClose()
 void Engine::OnWindowActivated()
 {
 	//SetPause(false);
-	LockCursor();
 }
 
 void Engine::OnWindowDeactivated()
 {
 	//SetPause(true);
-	UnlockCursor();
 }
 
 void Engine::OnWindowDpiScaleChanged()

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -437,6 +437,26 @@ void Engine::ClientTravel(const std::string& newURL, ETravelType travelType, boo
 {
 	UnrealURL url(newURL);
 
+	// If the URL doesn't contain the player info, add them here.
+	// As they have to persist somehow
+	for (std::string optionKey : { "Name", "Class", "team", "skin", "Face", "Voice", "OverrideClass" })
+	{
+		if (engine->packages->GetEngineVersion() > 219)
+		{
+			if (url.HasOption(optionKey))
+				engine->packages->SetIniValue("User", "DefaultPlayer", optionKey, url.GetOption(optionKey));
+			else
+				url.AddOrReplaceOption(optionKey + "=" + packages->GetIniValue("user", "DefaultPlayer", optionKey));
+		}
+		else
+		{
+			if (url.HasOption(optionKey))
+				engine->packages->SetIniValue("System", "URL", optionKey, url.GetOption(optionKey));
+			else
+				url.AddOrReplaceOption(optionKey + "=" + packages->GetIniValue("System", "URL", optionKey));
+		}
+	}
+
 	if (travelType == ETravelType::TRAVEL_Absolute)
 		ClientTravelInfo.URL = url;
 	else if (travelType == ETravelType::TRAVEL_Partial)
@@ -1406,11 +1426,13 @@ void Engine::OnWindowClose()
 void Engine::OnWindowActivated()
 {
 	//SetPause(false);
+	LockCursor();
 }
 
 void Engine::OnWindowDeactivated()
 {
 	//SetPause(true);
+	UnlockCursor();
 }
 
 void Engine::OnWindowDpiScaleChanged()

--- a/SurrealEngine/Native/NPlayerPawn.cpp
+++ b/SurrealEngine/Native/NPlayerPawn.cpp
@@ -97,7 +97,10 @@ void NPlayerPawn::UpdateURL(UObject* Self, const std::string& NewOption, const s
 	UPlayerPawn* SelfPlayerPawn = UObject::Cast<UPlayerPawn>(Self);
 	SelfPlayerPawn->Level()->URL.AddOrReplaceOption(NewOption + "=" + NewValue);
 	if (bSaveDefault)
-		LogUnimplemented("PlayerPawn.UpdateURL save default");
+	{
+		// Save the setting to DefaultUser section in User.ini
+		engine->packages->SetIniValue("User", "DefaultPlayer", NewOption, NewValue);
+	}
 }
 
 void NPlayerPawn::UpdateURL_219(UObject* Self, const std::string& NewOption)


### PR DESCRIPTION
`bSaveDefault` parameter on `NPlayerPawn::UpdateURL()` seems to be for saving the changes to User.ini's DefaultPlayer section. Implementing it is pretty easy.

`Engine::ClientTravel()` now adds the player info to URL it received, if such info isn't in the said URL. If there is info given in the URL however, it changes the relevant setting(s) instead. So having something like `open dig?name=[Name]` will change the player name to [Name], for example.

These two changes get the Player Setup dialog working.

I'm not entirely a fan of the additions I made in Engine::ClientTravel(), but I can always move that code somewhere else.