### PR TITLE
Replace FilePath class and Directory::files() with std::filesystem equivalents

### DIFF
--- a/SurrealEngine/Commandlet/ExportCommandlet.cpp
+++ b/SurrealEngine/Commandlet/ExportCommandlet.cpp
@@ -159,8 +159,8 @@ void ExportCommandlet::ExportScripts(DebuggerApp* console, Array<std::string>& p
 		std::string& name = pkgobject.second;
 
 		std::string pkgname = package->GetPackageName().ToString();
-		std::string pkgpath = FilePath::combine(engine->LaunchInfo.gameRootFolder, name);
-		std::string classespath = FilePath::combine(pkgpath, "Classes");
+		auto pkgpath = fs::path(engine->LaunchInfo.gameRootFolder) / name;
+		std::string classespath = (pkgpath / "Classes").string();
 		bool pkgpathcreated = false;
 
 		console->WriteOutput("Exporting scripts from " + ColorEscape(96) + name + ResetEscape() + NewLine());
@@ -178,8 +178,8 @@ void ExportCommandlet::ExportScripts(DebuggerApp* console, Array<std::string>& p
 					Directory::create(classespath);
 					pkgpathcreated = true;
 				}
-				std::string filename = FilePath::combine(classespath, cls->FriendlyName.ToString() + ".uc");
-				File::write_all_bytes(filename, stream.Data(), stream.Size());
+				const auto filename = fs::path(classespath) / (cls->FriendlyName.ToString() + ".uc");
+				File::write_all_bytes(filename.string(), stream.Data(), stream.Size());
 			}
 		}
 	}
@@ -251,8 +251,8 @@ void ExportCommandlet::ExportTextures(DebuggerApp* console, Array<std::string>& 
 		std::string& name = pkgobject.second;
 
 		std::string pkgname = package->GetPackageName().ToString();
-		std::string pkgpath = FilePath::combine(engine->LaunchInfo.gameRootFolder, name);
-		std::string texturespath = FilePath::combine(pkgpath, "Textures");
+		auto pkgpath = fs::path(engine->LaunchInfo.gameRootFolder) / name;
+		std::string texturespath = (pkgpath / "Textures").string();
 		bool pkgpathcreated = false;
 
 		console->WriteOutput("Exporting textures from " + ColorEscape(96) + name + ResetEscape() + NewLine());
@@ -278,7 +278,7 @@ void ExportCommandlet::ExportTextures(DebuggerApp* console, Array<std::string>& 
 					pkgpathcreated = true;
 				}
 
-				std::string filename = FilePath::combine(texturespath, tex->Name.ToString() + "." + ext);
+				std::string filename = fs::path(texturespath) / (tex->Name.ToString() + "." + ext);
 				File::write_all_bytes(filename, stream.Data(), stream.Size());
 			}
 		}

--- a/SurrealEngine/Commandlet/ExportCommandlet.cpp
+++ b/SurrealEngine/Commandlet/ExportCommandlet.cpp
@@ -174,7 +174,7 @@ void ExportCommandlet::ExportScripts(DebuggerApp* console, Array<std::string>& p
 			{
 				if (!pkgpathcreated)
 				{
-					Directory::create(pkgpath);
+					Directory::create(pkgpath.string());
 					Directory::create(classespath);
 					pkgpathcreated = true;
 				}
@@ -273,12 +273,12 @@ void ExportCommandlet::ExportTextures(DebuggerApp* console, Array<std::string>& 
 			{
 				if (!pkgpathcreated)
 				{
-					Directory::create(pkgpath);
+					Directory::create(pkgpath.string());
 					Directory::create(texturespath);
 					pkgpathcreated = true;
 				}
 
-				std::string filename = fs::path(texturespath) / (tex->Name.ToString() + "." + ext);
+				std::string filename = (fs::path(texturespath) / (tex->Name.ToString() + "." + ext)).string();
 				File::write_all_bytes(filename, stream.Data(), stream.Size());
 			}
 		}

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -1065,7 +1065,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 
 		for (auto& map : packages->GetMaps())
 		{
-			std::string mapname = fs::path(map).stem();
+			std::string mapname = fs::path(map).stem().string();
 
 			if (StrCompare::equals_ignore_case(mapname, url.Map))
 			{

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -743,9 +743,9 @@ void Engine::SaveGameToSlot(int32_t slotNum, const std::string& saveDescription)
 	}
 	else
 	{
-		std::string saveFolderPath = FilePath::combine(LaunchInfo.gameRootFolder, "Save");
-		std::string saveFileName = "Save" + std::to_string(slotNum) + "." + packages->GetSaveExtension();
-		std::string saveFileFullPath = FilePath::combine(saveFolderPath, saveFileName);
+		const auto saveFolderPath = fs::path(LaunchInfo.gameRootFolder) / "Save";
+		const std::string saveFileName = "Save" + std::to_string(slotNum) + "." + packages->GetSaveExtension();
+		const std::string saveFileFullPath = (saveFolderPath / saveFileName).string();
 		LevelPackage->Save(Level, saveFileFullPath);
 	}
 }
@@ -1016,7 +1016,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 
 		for (auto& map : packages->GetMaps())
 		{
-			std::string mapname = FilePath::remove_extension(map);
+			std::string mapname = fs::path(map).stem().string();
 
 			if (StrCompare::equals_ignore_case(mapname, url.Map))
 			{
@@ -1065,7 +1065,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 
 		for (auto& map : packages->GetMaps())
 		{
-			std::string mapname = FilePath::remove_extension(map);
+			std::string mapname = fs::path(map).stem();
 
 			if (StrCompare::equals_ignore_case(mapname, url.Map))
 			{
@@ -1078,7 +1078,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 	}
 	else if (command == "savegame" && args.size() == 2)
 	{
-		/*
+
 		int32_t slotNum;
 		// slotNum not being parsable shouldn't cause a crash
 		try
@@ -1091,8 +1091,8 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 		}
 
 		SaveGameToSlot(slotNum, "");
-		*/
-		LogMessage("SaveGame command not fully implemented yet!");
+
+		//LogMessage("SaveGame command not fully implemented yet!");
 		return {};
 	}
 	else if (command == "get" && args.size() == 3)

--- a/SurrealEngine/GameFolder.cpp
+++ b/SurrealEngine/GameFolder.cpp
@@ -69,7 +69,7 @@ GameLaunchInfo GameFolderSelection::ExamineFolder(const std::string& path)
 	if (ue1_game.first != KnownUE1Games::UE1_GAME_NOT_FOUND)
 	{
 		info.gameRootFolder = path;
-		info.gameExecutableName = FilePath::remove_extension(ue1_game.second);
+		info.gameExecutableName = fs::path(ue1_game.second).stem().string();
 
 		switch (ue1_game.first)
 		{
@@ -320,7 +320,7 @@ std::string GameFolderSelection::GetExePath()
 	if (GetModuleFileName(0, buffer.data(), 1024))
 	{
 		buffer.back() = 0;
-		return FilePath::remove_last_component(from_utf16(buffer.data()));
+		return fs::path(from_utf16(buffer.data())).parent_path().string();
 	}
 	return {};
 }

--- a/SurrealEngine/LauncherSettings.cpp
+++ b/SurrealEngine/LauncherSettings.cpp
@@ -12,7 +12,7 @@ LauncherSettings& LauncherSettings::Get()
 
 static std::string GetSettingsFilename()
 {
-	return fs::path(Directory::localAppData()) / "SurrealEngine/Settings.json";
+	return (Directory::localAppData() / "SurrealEngine/Settings.json").string();
 }
 
 LauncherSettings::LauncherSettings()
@@ -122,6 +122,6 @@ void LauncherSettings::Save()
 	settings["Games"] = std::move(games);
 
 	const std::string filename = GetSettingsFilename();
-	Directory::create(fs::path(filename).parent_path());
+	Directory::create(fs::path(filename).parent_path().string());
 	File::write_all_text(filename, settings.to_json(true));
 }

--- a/SurrealEngine/LauncherSettings.cpp
+++ b/SurrealEngine/LauncherSettings.cpp
@@ -12,7 +12,7 @@ LauncherSettings& LauncherSettings::Get()
 
 static std::string GetSettingsFilename()
 {
-	return FilePath::combine(Directory::localAppData(), "SurrealEngine/Settings.json");
+	return fs::path(Directory::localAppData()) / "SurrealEngine/Settings.json";
 }
 
 LauncherSettings::LauncherSettings()
@@ -121,7 +121,7 @@ void LauncherSettings::Save()
 	settings["RenderDevice"] = std::move(rendev);
 	settings["Games"] = std::move(games);
 
-	std::string filename = GetSettingsFilename();
-	Directory::create(FilePath::remove_last_component(filename));
+	const std::string filename = GetSettingsFilename();
+	Directory::create(fs::path(filename).parent_path());
 	File::write_all_text(filename, settings.to_json(true));
 }

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -390,7 +390,7 @@ std::unique_ptr<IniFile>& PackageManager::LoadUserIniFile()
 		if (!ini)
 		{
 			const auto iniFilePath = gameRootFolder / "System" / (launchInfo.gameExecutableName + ".ini");
-			ini = std::make_unique<IniFile>(iniFilePath);
+			ini = std::make_unique<IniFile>(iniFilePath.string());
 		}
 
 		return ini;
@@ -402,9 +402,9 @@ std::unique_ptr<IniFile>& PackageManager::LoadUserIniFile()
 	{
 		// Case sensitivity check
 		if (fs::exists(gameRootFolder / "System/User.ini"))
-			ini = std::make_unique<IniFile>(gameRootFolder / "System/User.ini");
+			ini = std::make_unique<IniFile>((gameRootFolder / "System/User.ini").string());
 		else
-			ini = std::make_unique<IniFile>(gameRootFolder/ "System/user.ini");
+			ini = std::make_unique<IniFile>((gameRootFolder/ "System/user.ini").string());
 	}
 
 	return ini;
@@ -419,29 +419,9 @@ std::unique_ptr<IniFile>& PackageManager::LoadSystemIniFile()
 	auto& ini = iniFiles[iniName];
 
 	if (!ini)
-		ini = std::make_unique<IniFile>(gameRootPath / "System" / (iniName + ".ini"));
+		ini = std::make_unique<IniFile>((gameRootPath / "System" / (iniName + ".ini")).string());
 
 	return ini;
-
-	/*
-	if (IsCliveBarkersUndying())
-	{
-		// Clive Barker's Undying uses System.ini instead of ExeName.ini
-		auto& ini = iniFiles["System"];
-
-		if (!ini)
-			ini = std::make_unique<IniFile>(gameRootPath / "System/System.ini");
-
-		return ini;
-	}
-
-	auto& ini = iniFiles[launchInfo.gameExecutableName];
-
-	if (!ini)
-		ini = std::make_unique<IniFile>(gameRootPath / "System" / (launchInfo.gameExecutableName + ".ini"));
-
-	return ini;
-	*/
 }
 
 
@@ -505,10 +485,10 @@ void PackageManager::SaveAllIniFiles()
 		if (iniFile.first == launchInfo.gameExecutableName || iniFile.first == "System")
 		{
 			const std::string engineIniName = "SE-" + iniFile.first.ToString() + ".ini";
-			iniFile.second->UpdateIfExists(systemFolderPath / engineIniName);
+			iniFile.second->UpdateIfExists((systemFolderPath / engineIniName).string());
 		}
 		else if (iniFile.first == "User")
-			iniFile.second->UpdateIfExists(systemFolderPath / "SE-User.ini");
+			iniFile.second->UpdateIfExists((systemFolderPath / "SE-User.ini").string());
 		else
 			iniFile.second->UpdateFile();
 	}
@@ -546,7 +526,7 @@ void PackageManager::LoadEngineIniFiles()
 	// Also load Default.ini, so that we can reset values.
 	defaultIniFile = std::make_unique<IniFile>((systemFolderPath / "Default.ini").string());
 
-	iniFiles[systemIniName] = std::make_unique<IniFile>(systemFolderPath / systemIniFileName);
+	iniFiles[systemIniName] = std::make_unique<IniFile>((systemFolderPath / systemIniFileName).string());
 
 	if (launchInfo.engineVersion > 219)
 	{
@@ -646,7 +626,7 @@ std::string PackageManager::Localize(NameString packageName, const NameString& s
 		{
 			const auto gameSystemFolder = fs::path(launchInfo.gameRootFolder) / "System";
 			const auto intFileName = fs::path(packageName.ToString() + ".int");
-			intFile = std::make_unique<IniFile>(gameSystemFolder / intFileName);
+			intFile = std::make_unique<IniFile>((gameSystemFolder / intFileName).string());
 		}
 		catch (...)
 		{

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -229,7 +229,7 @@ void PackageManager::ScanPaths()
 	{
 		for (const auto& dir_entry: fs::directory_iterator{systemFolderPath})
 		{
-			if (dir_entry.is_regular_file() && dir_entry.path().extension().string() == "avi")
+			if (dir_entry.is_regular_file() && dir_entry.path().extension().string() == ".avi")
 			{
 				auto fileName = dir_entry.path().filename();
 				aviFilenames[NameString(fileName.string())] = (systemFolderPath / fileName).string();

--- a/SurrealEngine/Package/PackageWriter.cpp
+++ b/SurrealEngine/Package/PackageWriter.cpp
@@ -20,7 +20,7 @@ void PackageWriter::Save(UObject* packageObject, std::string filename)
 	if (filename.empty())
 		filename = Source->GetPackageFilename();
 
-	std::string tempFilename = FilePath::remove_extension(filename) + ".tmp";
+	const std::string tempFilename = fs::path(filename).replace_extension(".tmp").string();
 
 	try
 	{

--- a/SurrealEngine/UE1GameDatabase.cpp
+++ b/SurrealEngine/UE1GameDatabase.cpp
@@ -17,10 +17,10 @@ std::pair<KnownUE1Games, std::string> FindUE1GameInPath(const std::string& ue1_g
 	{
 		auto executablePath = UE1GameSystemPath / executable_name;
 
-		if (File::try_open_existing(executablePath))
+		if (File::try_open_existing(executablePath.string()))
 		{
 			// Such executable exists, let's try to take SHA1Sum of it
-			auto bytes = File::read_all_bytes(executablePath);
+			auto bytes = File::read_all_bytes(executablePath.string());
 
 			sha1::SHA1 s;
 			s.processBytes(bytes.data(), bytes.size());

--- a/SurrealEngine/UE1GameDatabase.cpp
+++ b/SurrealEngine/UE1GameDatabase.cpp
@@ -2,26 +2,25 @@
 
 #include "Utils/File.h"
 #include "TinySHA1/TinySHA1.hpp"
-#include <filesystem>
 
 std::pair<KnownUE1Games, std::string> FindUE1GameInPath(const std::string& ue1_game_root_folder_path)
 {
 	if (ue1_game_root_folder_path.empty())
 		return std::make_pair(KnownUE1Games::UE1_GAME_NOT_FOUND, "");
 
-	if (!std::filesystem::exists(ue1_game_root_folder_path) || !std::filesystem::is_directory(ue1_game_root_folder_path))
+	if (!fs::exists(ue1_game_root_folder_path) || !fs::is_directory(ue1_game_root_folder_path))
 		return std::make_pair(KnownUE1Games::UE1_GAME_NOT_FOUND, "");
 
-	std::string ue1_game_system_path = FilePath::combine(ue1_game_root_folder_path, "System");
+	const auto UE1GameSystemPath = fs::path(ue1_game_root_folder_path) / "System";
 
 	for (auto& executable_name : knownUE1ExecutableNames)
 	{
-		std::string executable_path = FilePath::combine(ue1_game_system_path, executable_name);
+		auto executablePath = UE1GameSystemPath / executable_name;
 
-		if (File::try_open_existing(executable_path))
+		if (File::try_open_existing(executablePath))
 		{
 			// Such executable exists, let's try to take SHA1Sum of it
-			auto bytes = File::read_all_bytes(executable_path);
+			auto bytes = File::read_all_bytes(executablePath);
 
 			sha1::SHA1 s;
 			s.processBytes(bytes.data(), bytes.size());
@@ -34,7 +33,7 @@ std::pair<KnownUE1Games, std::string> FindUE1GameInPath(const std::string& ue1_g
 			std::string sha1sum(temp);
 
 			// Now check whether there is a match within the database or not
-			auto it = SHA1Database.find(sha1sum);
+			const auto it = SHA1Database.find(sha1sum);
 
 			if (it == SHA1Database.end())
 				return std::make_pair(KnownUE1Games::UE1_GAME_NOT_FOUND, "");

--- a/SurrealEngine/UI/Editor/EditorMainWindow.cpp
+++ b/SurrealEngine/UI/Editor/EditorMainWindow.cpp
@@ -119,17 +119,17 @@ void EditorMainWindow::OnFileOpen()
 	openFileDialog = OpenFileDialog::Create(this);
 	openFileDialog->SetTitle("Select Map");
 	openFileDialog->AddFilter("Map files", "*." + mapExtension);
-	openFileDialog->SetInitialDirectory(FilePath::combine(engine->LaunchInfo.gameRootFolder, "Maps"));
+	openFileDialog->SetInitialDirectory(fs::path(engine->LaunchInfo.gameRootFolder) / "Maps");
 
 	if (openFileDialog->Show())
 	{
 		// Load the map and all that stuff
-		auto mapFile = FilePath::last_component(openFileDialog->Filename());
-		auto mapName = FilePath::remove_extension(mapFile);
+		auto mapFile = fs::path(openFileDialog->Filename()).filename();
+		auto mapName = mapFile.stem().string();
 
 		LoadMap(mapName);
 
-		this->SetWindowTitle(mapFile + " - " + engine->LaunchInfo.gameName + " v" + engine->LaunchInfo.gameVersionString + " - Surreal Editor");
+		this->SetWindowTitle(mapFile.string() + " - " + engine->LaunchInfo.gameName + " v" + engine->LaunchInfo.gameVersionString + " - Surreal Editor");
 		// Refresh the viewports after loading the level
 		Update();
 	}

--- a/SurrealEngine/UI/Editor/EditorMainWindow.cpp
+++ b/SurrealEngine/UI/Editor/EditorMainWindow.cpp
@@ -119,7 +119,7 @@ void EditorMainWindow::OnFileOpen()
 	openFileDialog = OpenFileDialog::Create(this);
 	openFileDialog->SetTitle("Select Map");
 	openFileDialog->AddFilter("Map files", "*." + mapExtension);
-	openFileDialog->SetInitialDirectory(fs::path(engine->LaunchInfo.gameRootFolder) / "Maps");
+	openFileDialog->SetInitialDirectory((fs::path(engine->LaunchInfo.gameRootFolder) / "Maps").string());
 
 	if (openFileDialog->Show())
 	{

--- a/SurrealEngine/UI/ErrorWindow/ErrorWindow.cpp
+++ b/SurrealEngine/UI/ErrorWindow/ErrorWindow.cpp
@@ -48,9 +48,9 @@ bool ErrorWindow::CheckCrashReporter()
 	}
 	else
 	{
-		std::string reportsDirectory = FilePath::combine(Directory::localAppData(), "SurrealEngine/CrashReports");
-		Directory::create(reportsDirectory);
-		CrashReporter::Init(reportsDirectory, [](const std::string& logFilename) { Logger::Get()->SaveLog(logFilename); });
+		const auto reportsDirectory = fs::path(Directory::localAppData()) / "SurrealEngine/CrashReports";
+		Directory::create(reportsDirectory.string());
+		CrashReporter::Init(reportsDirectory.string(), [](const std::string& logFilename) { Logger::Get()->SaveLog(logFilename); });
 		return false;
 	}
 }

--- a/SurrealEngine/UI/WidgetResourceData.cpp
+++ b/SurrealEngine/UI/WidgetResourceData.cpp
@@ -10,7 +10,8 @@ static mz_zip_archive widgetResources;
 
 void InitWidgetResources()
 {
-	mz_bool result = mz_zip_reader_init_file(&widgetResources, (fs::path(OS::executable_path()) / "SurrealEngine.pk3").c_str(), 0);
+	const auto pk3PathStr = (fs::path{ OS::executable_path() } / "SurrealEngine.pk3").string();
+	mz_bool result = mz_zip_reader_init_file(&widgetResources, pk3PathStr.c_str(), 0);
 #ifndef WIN32
 	// On Linux, SurrealEngine.pk3 can additionally be put in some other folders given below.
 	if (!result)

--- a/SurrealEngine/UI/WidgetResourceData.cpp
+++ b/SurrealEngine/UI/WidgetResourceData.cpp
@@ -10,24 +10,26 @@ static mz_zip_archive widgetResources;
 
 void InitWidgetResources()
 {
-	mz_bool result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(OS::executable_path(), "SurrealEngine.pk3").c_str(), 0);
+	mz_bool result = mz_zip_reader_init_file(&widgetResources, (fs::path(OS::executable_path()) / "SurrealEngine.pk3").c_str(), 0);
 #ifndef WIN32
 	// On Linux, SurrealEngine.pk3 can additionally be put in some other folders given below.
 	if (!result)
-		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine("/usr/share/surrealengine", "SurrealEngine.pk3").c_str(), 0);
-	if (!result) {
-		char * home = std::getenv("HOME");
-		std::string directory = FilePath::combine(std::string(home) , ".local/share/surrealengine");
-		char * xdg_data_home = std::getenv("XDG_DATA_HOME");
-		if (xdg_data_home != NULL) {
-			directory = FilePath::combine(std::string(xdg_data_home), "surrealengine");
+		result = mz_zip_reader_init_file(&widgetResources, "/usr/share/surrealengine/SurrealEngine.pk3", 0);
+	if (!result)
+	{
+		char* home = std::getenv("HOME");
+		std::string directory = fs::path(home) / ".local/share/surrealengine";
+		char* xdg_data_home = std::getenv("XDG_DATA_HOME");
+		if (xdg_data_home != nullptr) {
+			directory = fs::path(xdg_data_home) / "surrealengine";
 		}
-		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(directory, "SurrealEngine.pk3").c_str(), 0);
+		result = mz_zip_reader_init_file(&widgetResources, (fs::path(directory) / "SurrealEngine.pk3").c_str(), 0);
 	}
-	if (!result) {
+	if (!result)
+	{
 		char * home = std::getenv("HOME");
-		std::string directory = FilePath::combine(std::string(home) , ".surrealengine");
-		result = mz_zip_reader_init_file(&widgetResources, FilePath::combine(directory, "SurrealEngine.pk3").c_str(), 0);
+		const std::string directory = fs::path(home) / ".surrealengine";
+		result = mz_zip_reader_init_file(&widgetResources, (fs::path(directory) / "SurrealEngine.pk3").c_str(), 0);
 	}
 #endif
 	if (!result)

--- a/SurrealEngine/Utils/File.cpp
+++ b/SurrealEngine/Utils/File.cpp
@@ -322,7 +322,7 @@ void Directory::create(const std::string& path)
 	}
 }
 
-std::string Directory::localAppData()
+fs::path Directory::localAppData()
 {
 	PWSTR path = nullptr;
 	if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_CREATE, nullptr, &path)))
@@ -367,7 +367,7 @@ void Directory::create(const std::string& dirname)
 	Exception::Throw("Could not create directory " + dirname);
 }
 
-std::string Directory::localAppData()
+fs::path Directory::localAppData()
 {
 	// We're trying to find "~/.config" here
 	const char* homeDir = getenv("HOME");
@@ -375,7 +375,7 @@ std::string Directory::localAppData()
 	if (!homeDir)
 		throw std::runtime_error("HOME environment variable is not set... somehow.");
 
-	return (fs::path(homeDir) / ".config").string();
+	return fs::path(homeDir) / ".config";
 }
 
 #endif

--- a/SurrealEngine/Utils/File.h
+++ b/SurrealEngine/Utils/File.h
@@ -63,7 +63,7 @@ class Directory
 {
 public:
 	static void create(const std::string& path);
-	static std::string localAppData();
+	static fs::path localAppData();
 };
 
 class OS

--- a/SurrealEngine/VM/Iterator.cpp
+++ b/SurrealEngine/VM/Iterator.cpp
@@ -38,7 +38,7 @@ AllFilesIterator::AllFilesIterator(const std::string& FileExtension, const std::
 	{
 		auto package = engine->packages->GetPackage(packageName);
 
-		if ((FileExtension.empty() || FilePath::extension(package->GetPackageFilename()) == FileExtension) && 
+		if ((FileExtension.empty() || fs::path(package->GetPackageFilename()).extension().string() == FileExtension) &&
 			(FilePrefix.empty() || package->GetPackageFilename().find(FilePrefix) != std::string::npos))
 		{
 			FoundFiles.push_back(packageName.ToString());


### PR DESCRIPTION
This can be improved, namely with replacing `std::string` path parameters in functions with `std::filesystem::path` ones where appropriate; as well as replacing `Directory::create()` with `std::filesystem::create_directory()`... maybe.

Still what we got here doesn't break anything to my testings so far.