### PR TITLE
Implemented CrashReporter for macOS

### DIFF
--- a/SurrealEngine/Utils/CrashReporter.cpp
+++ b/SurrealEngine/Utils/CrashReporter.cpp
@@ -3,6 +3,7 @@
 #include "CrashReporter.h"
 #include "UTF16.h"
 #include <stdexcept>
+#include <sys/signal.h>
 
 #ifdef WIN32
 #ifdef _MSC_VER
@@ -820,6 +821,179 @@ CrashDumpInfo CrashReporter::GetCrashDumpInfo(const std::string& dumpFilename)
 }
 
 #endif // _MSC_VER
+#elif defined(__APPLE__)
+
+#include <cstring>
+#include <cstdio>
+#include <cerrno>
+#include <ctime>
+#include <sys/sysctl.h>
+#include <sys/syslimits.h>
+#include <signal.h>
+#include <unistd.h>
+
+static const char fatal_err[] = "\n\n* Fatal Error :(\n";
+
+struct SignalInfo
+{
+	int code;
+	const char* name = "";
+};
+
+constexpr SignalInfo signals[] = {
+	{ SIGSEGV, "SIGSEGV" },
+	{ SIGILL, "SIGILL" },
+	{ SIGFPE, "SIGFPE" },
+	{ SIGBUS, "SIGBUS" },
+	{ SIGABRT, "SIGABRT" },
+};
+
+static std::string logFileFullname;
+static std::function<void(const std::string&)> saveLogCallback;
+
+static volatile sig_atomic_t origSignum = 0;
+static volatile sig_atomic_t handlerIsRunning = 0;
+
+static size_t safe_write(int fd, const void* buf, size_t len)
+{
+	size_t ret = 0;
+	while (ret < len)
+	{
+		const ssize_t rem = write(fd, (const char*)buf + ret, len - ret);
+		if (rem == -1)
+		{
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+		ret += rem;
+	}
+	return ret;
+}
+
+static void crash_catcher(int signum, siginfo_t* /*siginfo*/, void* /*context*/)
+{
+	// Prevent hang on deadlock, see below. This will save you from force closing
+	// the app, and preserve the .ips in most cases
+	alarm(2);
+
+	// the same signal should not be sent to the handler twice,
+	// but a different signal could. Also, this path is used by alarm().
+	if (handlerIsRunning != 0)
+	{
+		signal(origSignum, SIG_DFL);
+		raise(origSignum);
+		_exit(1);
+	}
+
+	handlerIsRunning = 1;
+	// store in case of alarm()
+	origSignum = signum;
+
+	safe_write(STDERR_FILENO, fatal_err, sizeof(fatal_err) - 1);
+
+	// the callback is not async safe and may cause a deadlock.
+	// the alarm() call above kills the process after a timeout if a deadlock occurs.
+	saveLogCallback(logFileFullname);
+
+	raise(signum);
+}
+
+static bool isDebuggerPresent()
+{
+	struct kinfo_proc procInfo;
+	std::memset(&procInfo, 0, sizeof(procInfo));
+
+	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
+
+	size_t size = sizeof(procInfo);
+	if (sysctl(mib, std::size(mib), &procInfo, &size, nullptr, 0) == -1)
+	{
+		return false;
+	}
+
+	return (procInfo.kp_proc.p_flag & P_TRACED) != 0;
+}
+
+void CrashReporter::Init(const std::string& reportsDirectory, std::function<void(const std::string& logFilename)> saveLog)
+{
+	// Will not attach if a debugger is present. Note, if a debugger is attached
+	// later the handler will be present and interfere with the debugger
+	if (isDebuggerPresent())
+	{
+		fprintf(stderr, "Debugger detected, crash handler not installed\n");
+		return;
+	}
+
+	// build log file name, same pattern as Windows but with space replace with underscore
+	time_t t = time(nullptr);
+	tm timevalue{};
+	localtime_r(&t, &timevalue);
+	char fileName[64];
+	strftime(fileName, sizeof(fileName), "%Y-%m-%d_%H.%M.%S.log", &timevalue);
+
+	logFileFullname = reportsDirectory;
+	if (!logFileFullname.empty() && logFileFullname.back() != '/')
+		logFileFullname += '/';
+	logFileFullname += fileName;
+
+	saveLogCallback = saveLog;
+
+	// Stack-overflow safe signal stack
+	static char* altstack = new char[SIGSTKSZ];
+	stack_t altss;
+	altss.ss_sp = altstack;
+	altss.ss_flags = 0;
+	altss.ss_size = SIGSTKSZ;
+	if (sigaltstack(&altss, nullptr) == -1)
+	{
+		fprintf(stderr, "Failed to call sigaltstack: %s (errno %d)\n", strerror(errno), errno);
+		return;
+	}
+
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_sigaction = crash_catcher;
+	sa.sa_flags = SA_RESETHAND | SA_NODEFER | SA_SIGINFO | SA_ONSTACK;
+	if (sigemptyset(&sa.sa_mask) == -1)
+	{
+		fprintf(stderr, "Failed to call sigemptyset: %s (errno %d)\n", strerror(errno), errno);
+		return;
+	}
+
+	for (const SignalInfo& signal : signals)
+	{
+		if (sigaction(signal.code, &sa, nullptr) == -1)
+		{
+			fprintf(stderr, "Failed to call sigaction for %s: %s (errno %d)\n", signal.name, strerror(errno), errno);
+			return;
+		}
+	}
+
+	// alarm is not a crash signal so not in the array, register it separately
+	sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+	if (sigaction(SIGALRM, &sa, nullptr) == -1)
+	{
+		fprintf(stderr, "Failed to call sigaction for SIGALRM: %s (errno %d)\n", strerror(errno), errno);
+		return;
+	}
+	return;
+}
+
+void CrashReporter::HookThread()
+{
+	// Noop on *nix and MacOS. No need to hook into threads
+}
+
+void CrashReporter::Invoke()
+{
+}
+
+CrashDumpInfo CrashReporter::GetCrashDumpInfo(const std::string& dumpFilename)
+{
+	return {};
+}
+
 #else // Linux
 
 void CrashReporter::Init(const std::string& reportsDirectory, std::function<void(const std::string& logFilename)> saveLog)


### PR DESCRIPTION
**Description**
CrashReporter is only implemented for Windows+MSVC - this adds macOS support. Without this, a crash in the engine loses the entire log. Logs are only written during benign engine destruction which never happens on a crash.

This implementation could probably easily be extended to cover linux, but I don't have a linux box handy to test on.

Captures crashing signals and handles stack overflow crashes. It will preserve logs and macOS .ips crash report files in _most_ cases. 
It uses signals and not mach exceptions since signals are simpler and sufficient; using signals is also almost identical to *nix handling.

Respects running under a debugger - if process starts under debugger, signal handler is not installed. 

**Limitations**

- Logger::SaveLog is not async-signal-safe; it allocates memory and calls iostream. A crash in allocator would lead to deadlock - hence the alarm() guard which saves you from having to force close, and preserves the .ips but not the log file.
the proper fix for this is to make Logger async safe and/or stream the logs, but that is a larger design change.
- HookThread() is left a no-op. Signals are process wide and get handled regardless of which thread faults. Altstack however is per-thread. The consequence is that stack overflows on other threads than the one calling Init() theoretically could lose the log file. However, when testing on macOS shows it works even with stack overflow on non-main thread, and the .ips is preserved. This may be an issue when/if extending to support *nix.
- No guarantee in case of kernel uninterruptible waits (this is the "_most cases" above).

**Testing**
macOS 26.6 arm64, Apple clang 21, RelWithDebInfo.

- Real crash (null deref in URootWindow::SetRootFocusWindow, running Deus Ex 1112fm): log written, .ips still produced, exit 139.
- Simulated deadlock in the save callback: SIGALRM fired, original SIGSEGV re-raised, exit 139, .ips still written.
- Stack overflow on a secondary thread: delivered as SIGBUS, handler ran, .ips written.