### PR TITLE
Implement lipsync (for Deus Ex)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -918,6 +918,8 @@ set(THIRDPARTY_SOURCES
 	Thirdparty/miniz/miniz.h
 	Thirdparty/kissfft/kiss_fft.c
 	Thirdparty/kissfft/kiss_fft.h
+	Thirdparty/kissfft/kiss_fftr.c
+	Thirdparty/kissfft/kiss_fftr.h
 )
 
 set(THIRDPARTY_WIN32_SOURCES

--- a/SurrealEngine/Packages/Engine/Resources/USound.cpp
+++ b/SurrealEngine/Packages/Engine/Resources/USound.cpp
@@ -5,6 +5,10 @@
 #include "Audio/AudioSource.h"
 #include "Audio/AudioDevice.h"
 #include "Packages/Engine/Subsystems/USurrealAudioDevice.h"
+#include "kissfft/kiss_fftr.h"
+
+#include <algorithm>
+#include <type_traits>
 
 void USound::Load(ObjectStream* stream)
 {
@@ -80,4 +84,92 @@ int USound::GetChannels()
 		GetSound();
 
 	return channels;
+}
+
+const Array<uint8_t>& USound::GetLipsyncLetters()
+{
+	if(!lipsyncLetters.empty())
+		return lipsyncLetters;
+
+	GetSound();
+
+	if (channels != 1)
+		return lipsyncLetters;
+
+	// guard against empty sound or decoding error
+	if (samples.empty())
+		return lipsyncLetters;
+
+	static const float MIN_VOLUME = 0.02f;
+
+	std::unique_ptr<kiss_fftr_state, void(*)(void*)> fftcfg(kiss_fftr_alloc(LIPSYNC_BLOCK_SIZE, 0, nullptr, nullptr), free);
+
+	if (!fftcfg)
+		return lipsyncLetters;
+
+	Array<kiss_fft_cpx> freq(LIPSYNC_BLOCK_SIZE / 2 + 1);
+	float binHz = frequency / (float)LIPSYNC_BLOCK_SIZE;
+
+	for(size_t i = 0; i + LIPSYNC_BLOCK_SIZE <= samples.size(); i += LIPSYNC_BLOCK_SIZE)
+	{
+		float maxVolume = 0.0f;
+
+		for(size_t j = i; j < i + LIPSYNC_BLOCK_SIZE; ++j)
+			maxVolume = std::max(maxVolume, std::fabs(samples[j]));
+
+		if (maxVolume < MIN_VOLUME)
+		{
+			lipsyncLetters.push_back('X');
+			continue;
+		}
+		kiss_fftr(fftcfg.get(), samples.data() + i, freq.data());
+
+		float bestMagn = 0.0f;
+		int bestBin = 0;
+		for(int b = 1; b < LIPSYNC_BLOCK_SIZE / 2 + 1; b++)
+		{
+			float magn = freq[b].r * freq[b].r + freq[b].i * freq[b].i;
+			if (magn > bestMagn)
+			{
+				bestMagn = magn;
+				bestBin = b;
+			}
+		}
+
+		lipsyncLetters.push_back(LetterForHz(bestBin * binHz));
+	}
+
+	return lipsyncLetters;
+}
+
+uint8_t USound::LetterForHz(float hz)
+{
+	struct Band {
+		float hzCutoff;
+		uint8_t letter;
+	};
+	static const Band bands[] =
+	{
+		{100.0f, 'E'},
+		{250.0f, 'M'},
+		{400.0f, 'U'},
+		{600.0f, 'O'},
+		{1500.0f, 'A'},
+		{2000.0f, 'F'},
+	};
+	for(const Band& b: bands)
+		if(hz < b.hzCutoff)
+			return b.letter;
+
+	return 'T';
+}
+
+uint8_t USound::GetLipsyncLetterAt(float seconds)
+{
+	const Array<uint8_t>& letters = GetLipsyncLetters();
+	if(letters.empty())
+		return 0;
+
+	int block = (int)(seconds * frequency / LIPSYNC_BLOCK_SIZE);
+	return letters[std::max(0, std::min(block, (int)letters.size() - 1))];
 }

--- a/SurrealEngine/Packages/Engine/Resources/USound.h
+++ b/SurrealEngine/Packages/Engine/Resources/USound.h
@@ -38,4 +38,13 @@ public:
 	int channels = 0;
 	void* handle = nullptr;
 	AudioLoopInfo loopInfo;
+
+	Array<uint8_t> lipsyncLetters;
+
+	uint8_t GetLipsyncLetterAt(float seconds);
+
+private:
+	static uint8_t LetterForHz(float hz);
+	static constexpr int LIPSYNC_BLOCK_SIZE = 2048;
+	const Array<uint8_t>& GetLipsyncLetters();
 };

--- a/SurrealEngine/Packages/Engine/Subsystems/USurrealAudioDevice.cpp
+++ b/SurrealEngine/Packages/Engine/Subsystems/USurrealAudioDevice.cpp
@@ -7,6 +7,7 @@
 #include "Packages/Engine/UViewport.h"
 #include "Packages/Engine/Actors/UActor.h"
 #include "Packages/Engine/Actors/Pawn/UPlayerPawn.h"
+#include "Packages/Engine/Actors/Pawn/UPawn.h"
 #include "Packages/Engine/Actors/Info/ULevelInfo.h"
 #include "Packages/Engine/Resources/UMusic.h"
 #include "Packages/Engine/Resources/USound.h"
@@ -253,6 +254,55 @@ void USurrealAudioDevice::UpdateAmbience()
 	}
 }
 
+//
+// Deliberately stores no state on PlayingSound. The slot is already packed into Id by
+// NActor::PlaySound as (slot << 1), and this file already decodes it that way for
+// SLOT_Ambient, so SLOT_Talk is recoverable the same way.
+//
+// PropertyOffsets only resolves the lip-sync properties inside its IsDeusEx() branch, so an
+// unset offset doubles as the "this game has no lip sync" test: other games return on the
+// first line and observe no behaviour change at all.
+static bool HasLipSync()
+{
+	return PropOffsets_Pawn.nextPhoneme.DataOffset != ~(size_t)0;
+}
+
+void USurrealAudioDevice::UpdateLipSync(PlayingSound& Playing)
+{
+	if (!HasLipSync() || !Playing.Actor || !engine->LevelInfo)
+		return;
+	if ((Playing.Id & 14) != SLOT_Talk * 2)
+		return;
+
+	UPawn* pawn = UObject::TryCast<UPawn>(Playing.Actor);
+	if (!pawn)
+		return;
+
+	float elapsedTime = engine->LevelInfo->TimeSeconds() - Playing.StartTime;
+	uint8_t letter = Playing.Sound->GetLipsyncLetterAt(elapsedTime);
+
+	if (!letter)
+		return;
+
+	pawn->bIsSpeaking() = true;
+	pawn->nextPhoneme() = std::string(1, letter);
+}
+
+// Called wherever a slot is torn down, so the mouth does not freeze mid-vowel.
+void USurrealAudioDevice::ClearLipSync(PlayingSound& Playing)
+{
+	if (!HasLipSync() || !Playing.Actor)
+		return;
+	if ((Playing.Id & 14) != SLOT_Talk * 2)
+		return;
+
+	if (UPawn* pawn = UObject::TryCast<UPawn>(Playing.Actor))
+	{
+		pawn->bIsSpeaking() = false;
+		pawn->nextPhoneme() = "X";   // X == MouthClosed
+	}
+}
+
 void USurrealAudioDevice::UpdateSounds(const mat4& listener)
 {
 	if (!m_Viewport || !m_Viewport->Actor())
@@ -272,6 +322,8 @@ void USurrealAudioDevice::UpdateSounds(const mat4& listener)
 			// Update the priority
 			Playing.Priority = SoundPriority(m_Viewport, Playing.Location, Playing.Volume, Playing.Radius);
 
+			UpdateLipSync(Playing);
+
 			// Update the sound.
 			if (Playing.IsActive)
 			{
@@ -281,6 +333,7 @@ void USurrealAudioDevice::UpdateSounds(const mat4& listener)
 				}
 				else
 				{
+					ClearLipSync(Playing);
 					PlayingSounds[i] = {};
 				}
 			}
@@ -390,6 +443,7 @@ bool USurrealAudioDevice::PlaySound(UActor* Actor, int Id, USound* Sound, vec3 L
 	// Put the sound on the play-list
 	StopSound(Index);
 	PlayingSounds[Index] = PlayingSound(Actor, Id, Sound, Location, Volume, Radius, Pitch, Priority);
+	PlayingSounds[Index].StartTime = engine->LevelInfo->TimeSeconds();
 
 	return true;
 }
@@ -436,6 +490,7 @@ void USurrealAudioDevice::StopSound(size_t index)
 		Playing.IsActive = false;
 	}
 
+	ClearLipSync(Playing);
 	PlayingSounds[index] = {};
 }
 

--- a/SurrealEngine/Packages/Engine/Subsystems/USurrealAudioDevice.h
+++ b/SurrealEngine/Packages/Engine/Subsystems/USurrealAudioDevice.h
@@ -23,6 +23,7 @@ struct PlayingSound
 	float Volume = 1.0f;
 	float Radius = 1.0f;
 	float Pitch = 1.0f;
+	float StartTime = 0.0f;
 };
 
 class USurrealAudioDevice : public UAudioSubsystem
@@ -75,6 +76,9 @@ private:
 	void StartAmbience();
 	void UpdateAmbience();
 	void UpdateSounds(const mat4& listener);
+
+	void UpdateLipSync(PlayingSound& Playing);
+	void ClearLipSync(PlayingSound& Playing);
 	void UpdateMusic();
 	void StopSound(size_t index);
 


### PR DESCRIPTION
Implementing lip-syncing in the engine. 
Added FFT processing to USound, and consuming the data from USurrealAudioDevice, which pushes it to pawns via the existing properties bIsSpeaking and nextPhoneme.
Samples are processed in blocks of 2048 based on some very quick testing, mouth movements were very jittery at 1024.
Configuration of the processing (block size, max frequency selection, volume threshold, frequency-to-letter bands, etc) will need tweaking later, but that is currently blocked by performance issues (the framerate is 10-15 fps in-game on my system). 

kiss_fftr.h + .c were added to CMakeLists.txt. real value is sufficient for the use case.

The analysis is done lazy upon request. Maybe it could be reasonably precomputed somewhere.

Only mono sounds are supported - stereo files will return empty phoneme lists.

Playback position is driven by system clock - it is not currently synced to the audio playback. Start time is taken from Level.TimeSeconds on start.