### PR TITLE
Fix DynamicArray cast bug

### DIFF
--- a/SurrealEngine/Packages/Core/UObject.h
+++ b/SurrealEngine/Packages/Core/UObject.h
@@ -364,7 +364,7 @@ public:
 	}
 
 	template<typename T>
-	TypedScriptArray<T> DynamicArray(PropertyDataOffset offset) { return *static_cast<TypedScriptArray<T>*>(PropertyData.Ptr(offset.DataOffset)); }
+	TypedScriptArray<T> DynamicArray(PropertyDataOffset offset) { return TypedScriptArray<T>(static_cast<ScriptArray*>(PropertyData.Ptr(offset.DataOffset))); }
 
 	template<typename T>
 	static T* Cast(UObject* obj)


### PR DESCRIPTION
DynamicArray in UObject.h has a bad cast. Since this is in shared code I'm submitting this on its own for review.

```
template<typename T> TypedScriptArray<T> DynamicArray(PropertyDataOffset offset)
{
    return *static_cast<TypedScriptArray<T>*>(PropertyData.Ptr(offset.DataOffset));
}
```

This casts the ScriptArray as a TypedScriptArray, which is not a compatible type. The intended pattern is to wrap the ScriptArray in the TypedScriptArray->Array field.
The correct cast is:

`return TypedScriptArray<T>(static_cast<ScriptArray*>(PropertyData.Ptr(offset.DataOffset)));` 

This gives the script array wrapped in a TypedScriptArray.

There appears to be very few or no other callers than DeusEx code, and all Deus Ex callers were #if 0. 
Reading from this array silently fails most of the times, but writing to it crashes. The DX call sites currently does not compile. Here's how to repro - in Packages/DeusEx/UGameDirectory.cpp, and the following two lines at the start of GetDirCount(). Before the proposed fix the game will crash when opening the Load Save dialog, after the fix it does not. (still does not work, but more on that in the next PR)


```
LoadedSaveInfoPointers().push_back(nullptr);
LoadedSaveInfoPointers().pop_back();
```