### PR TITLE
Vulkan: Fix off-by-one error in MSAA sample count selection

### DIFF
--- a/SurrealEngine/RenderDevice/Vulkan/SceneTextures.cpp
+++ b/SurrealEngine/RenderDevice/Vulkan/SceneTextures.cpp
@@ -171,13 +171,13 @@ SceneTextures::~SceneTextures()
 VkSampleCountFlagBits SceneTextures::GetBestSampleCount(VulkanDevice* device, int multisample)
 {
 	const auto& limits = device->PhysicalDevice.Properties.Properties.limits;
-	int requestedSamples = clamp(multisample, 0, 64);
+	int requestedSamples = clamp(multisample, 1, 64);
 	VkSampleCountFlags deviceSampleCounts = limits.sampledImageColorSampleCounts & limits.sampledImageDepthSampleCounts & limits.sampledImageStencilSampleCounts;
 
 	int samples = 1;
 	VkSampleCountFlags bit = VK_SAMPLE_COUNT_1_BIT;
 	VkSampleCountFlags best = bit;
-	while (samples < requestedSamples)
+	while (samples <= requestedSamples)
 	{
 		if (deviceSampleCounts & bit)
 		{


### PR DESCRIPTION
Vulkan MSAA had a simple off-by-one error when resolving requested samples against highest supported sample count (requesting 2x MSAA would give 1x sample, 4x would give 2x, etc).

I also made a clarity improvement to `clamp` to reflect the meaningful range