### PR TITLE
Add stubs for Unreal 227 exclusive StaticLightData and StaticMeshActor objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,7 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/Packages/Engine/Actors/UProjectile.h
 	SurrealEngine/Packages/Engine/Actors/UProjector.h
 	SurrealEngine/Packages/Engine/Actors/USkeletalMeshInstance.h
+	SurrealEngine/Packages/Engine/Actors/UStaticMeshActor.h
 	SurrealEngine/Packages/Engine/Actors/USpawnNotify.h
 	SurrealEngine/Packages/Engine/Actors/Brush/UBrush.h
 	SurrealEngine/Packages/Engine/Actors/Brush/UMover.h
@@ -613,6 +614,7 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/Packages/Engine/Resources/UPrimitive.h
 	SurrealEngine/Packages/Engine/Resources/USound.cpp
 	SurrealEngine/Packages/Engine/Resources/USound.h
+	SurrealEngine/Packages/Engine/Resources/UStaticLightData.h
 	SurrealEngine/Packages/Engine/Resources/Level/UBspNodes.cpp
 	SurrealEngine/Packages/Engine/Resources/Level/UBspNodes.h
 	SurrealEngine/Packages/Engine/Resources/Level/UBspSurfs.cpp

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -112,6 +112,7 @@
 #include "Packages/Engine/Actors/UProjector.h"
 #include "Packages/Engine/Actors/USkeletalMeshInstance.h"
 #include "Packages/Engine/Actors/USpawnNotify.h"
+#include "Packages/Engine/Actors/UStaticMeshActor.h"
 #include "Packages/Engine/Actors/Brush/UBrush.h"
 #include "Packages/Engine/Actors/Brush/UMover.h"
 #include "Packages/Engine/Actors/Decoration/UCarcass.h"
@@ -169,6 +170,7 @@
 #include "Packages/Engine/Resources/UPalette.h"
 #include "Packages/Engine/Resources/UPrimitive.h"
 #include "Packages/Engine/Resources/USound.h"
+#include "Packages/Engine/Resources/UStaticLightData.h"
 #include "Packages/Engine/Resources/Level/UBspNodes.h"
 #include "Packages/Engine/Resources/Level/UBspSurfs.h"
 #include "Packages/Engine/Resources/Level/ULevel.h"
@@ -1292,6 +1294,8 @@ void PackageManager::RegisterNativeClasses()
 	{
 		RegisterNativeClass<U227SkeletalMeshInstance>(enginePackage, "SkeletalMeshInstance", "Object");
 		RegisterNativeClass<U227AnimationNotify>(enginePackage, "AnimationNotify", "Object");
+		RegisterNativeClass<UStaticLightData>(enginePackage, "StaticLightData", "Object");
+		RegisterNativeClass<UStaticMeshActor>(enginePackage, "StaticMeshActor", "Actor");
 		RegisterNativeClass<UInventoryAttachment>(enginePackage, "InventoryAttachment", "Actor");
 		RegisterNativeClass<UWeaponAttachment>(enginePackage, "WeaponAttachment", "InventoryAttachment");
 		RegisterNativeClass<UWeaponMuzzleFlash>(enginePackage, "WeaponMuzzleFlash", "InventoryAttachment");

--- a/SurrealEngine/Packages/Engine/Actors/UStaticMeshActor.h
+++ b/SurrealEngine/Packages/Engine/Actors/UStaticMeshActor.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "UActor.h"
+#include "Packages/Engine/Resources/UStaticLightData.h"
+
+// Unreal 227 class
+// UnrealEd adds this actor when one selects the "Add Mesh Here" option
+class UStaticMeshActor : public UActor
+{
+public:
+    using UActor::UActor;
+
+    UStaticLightData*& StaticLightD() { return Value<UStaticLightData*>(PropOffsets_StaticMeshActor.StaticLightD); }
+    BitfieldBool bBuildStaticLights() { return BoolValue(PropOffsets_StaticMeshActor.bBuildStaticLights); }
+    BitfieldBool bComputeUnlitColor() { return BoolValue(PropOffsets_StaticMeshActor.bComputeUnlitColor); }
+};

--- a/SurrealEngine/Packages/Engine/Resources/UStaticLightData.h
+++ b/SurrealEngine/Packages/Engine/Resources/UStaticLightData.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Packages/Core/UObject.h"
+
+// Unreal 227 class
+// Attached to static meshes?
+class UStaticLightData : public UObject
+{
+public:
+    using UObject::UObject;
+
+    BitfieldBool HasLightmap() { return BoolValue(PropOffsets_StaticLightData.HasLightmap); }
+};

--- a/SurrealEngine/PropertyOffsets.cpp
+++ b/SurrealEngine/PropertyOffsets.cpp
@@ -5453,6 +5453,36 @@ static void InitPropertyOffsets_SkeletalMeshInstance(PackageManager* packages)
 	PropOffsets_SkeletalMeshInstance.HardAttachFlags = cls->GetPropertyDataOffset("HardAttachFlags");
 }
 
+PropertyDataOffsets_StaticLightData PropOffsets_StaticLightData;
+
+static void InitPropertyOffsets_StaticLightData(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Engine")->GetUObject("Class", "StaticLightData"));
+	if (!cls)
+	{
+		memset(&PropOffsets_StaticLightData, 0xff, sizeof(PropOffsets_StaticLightData));
+		return;
+	}
+
+	PropOffsets_StaticLightData.HasLightmap = cls->GetPropertyDataOffset("HasLightmap");
+}
+
+PropertyDataOffsets_StaticMeshActor PropOffsets_StaticMeshActor;
+
+static void InitPropertyOffsets_StaticMeshActor(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Engine")->GetUObject("Class", "StaticMeshActor"));
+	if (!cls)
+	{
+		memset(&PropOffsets_StaticMeshActor, 0xff, sizeof(PropOffsets_StaticMeshActor));
+		return;
+	}
+
+	PropOffsets_StaticMeshActor.StaticLightD = cls->GetPropertyDataOffset("StaticLightD");
+	PropOffsets_StaticMeshActor.bBuildStaticLights = cls->GetPropertyDataOffset("bBuildStaticLights");
+	PropOffsets_StaticMeshActor.bComputeUnlitColor = cls->GetPropertyDataOffset("bComputeUnlitColor");
+}
+
 //////////////////////////////////////////
 
 PropertyDataOffsets_RMusic_Player PropOffsets_RMusic_Player;
@@ -5603,6 +5633,7 @@ void InitPropertyOffsets(PackageManager* packages)
 		InitPropertyOffsets_XRainRestrictionVolume(packages);
 		InitPropertyOffsets_DynamicZoneInfo(packages);
 		InitPropertyOffsets_Projector(packages);
+		InitPropertyOffsets_StaticLightData(packages);
 	}
 	if (packages->IsDeusEx())
 	{

--- a/SurrealEngine/PropertyOffsets.h
+++ b/SurrealEngine/PropertyOffsets.h
@@ -4350,6 +4350,22 @@ struct PropertyDataOffsets_AnimationNotify
 
 extern PropertyDataOffsets_AnimationNotify PropOffsets_AnimationNotify;
 
+struct PropertyDataOffsets_StaticLightData
+{
+	PropertyDataOffset HasLightmap;
+};
+
+extern PropertyDataOffsets_StaticLightData PropOffsets_StaticLightData;
+
+struct PropertyDataOffsets_StaticMeshActor
+{
+	PropertyDataOffset StaticLightD;
+	PropertyDataOffset bBuildStaticLights;
+	PropertyDataOffset bComputeUnlitColor;
+};
+
+extern PropertyDataOffsets_StaticMeshActor PropOffsets_StaticMeshActor;
+
 struct PropertyDataOffsets_RMusic_Player
 {
 	PropertyDataOffset RMusic_Volume;


### PR DESCRIPTION
Sadly DmRiot, which is the main reason for these additions, still crashes.